### PR TITLE
Migrate chart from helm/stable, add license and CI/CD pipelines

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,39 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.1.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The Helm Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # manifests
+
 For hosting manifests to allow for the deployment of OAuth2-Proxy/OAuth2-Proxy
+
+## Helm Chart
+
+The helm chart in this repo is based on the community chart from the deprecated [helm/stable repo](https://github.com/helm/charts/tree/master/stable/oauth2-proxy)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ For hosting manifests to allow for the deployment of OAuth2-Proxy/OAuth2-Proxy
 ## Helm Chart
 
 The helm chart in this repo is based on the community chart from the deprecated [helm/stable repo](https://github.com/helm/charts/tree/master/stable/oauth2-proxy)
+
+Linting/validation uses the [helm/chart-testing tool](https://github.com/helm/chart-testing). To run it locally you need to place [two schema files](https://github.com/helm/chart-testing/blob/master/etc/lintconf.yaml) in `~/.ct` or `/etc/ct`.
+
+```bash
+ct lint --all --config ct.yaml
+ct install --all --config ct.yaml
+```

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+
+OWNERS

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,18 @@
+name: oauth2-proxy
+version: 3.2.5
+apiVersion: v1
+appVersion: 5.1.0
+home: https://pusher.github.io/oauth2_proxy/
+description: DEPRECATED - A reverse proxy that provides authentication with Google, Github or other providers
+keywords:
+- kubernetes
+- oauth
+- oauth2
+- authentication
+- google
+- github
+deprecated: true
+sources:
+- https://github.com/pusher/oauth2_proxy
+engine: gotpl
+kubeVersion: ">=1.9.0-0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ name: oauth2-proxy
 version: 3.2.5
 apiVersion: v1
 appVersion: 5.1.0
-home: https://pusher.github.io/oauth2_proxy/
+home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
 - kubernetes
@@ -12,6 +12,11 @@ keywords:
 - google
 - github
 sources:
-- https://github.com/pusher/oauth2_proxy
+- https://github.com/oauth2-proxy/oauth2-proxy
+- https://github.com/oauth2-proxy/manifests
+maintainers:
+- email: cedric@desaintmartin.fr
+  name: desaintmartin
+- name: tlawrie
 engine: gotpl
 kubeVersion: ">=1.9.0-0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ version: 3.2.5
 apiVersion: v1
 appVersion: 5.1.0
 home: https://pusher.github.io/oauth2_proxy/
-description: DEPRECATED - A reverse proxy that provides authentication with Google, Github or other providers
+description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
 - kubernetes
 - oauth
@@ -11,7 +11,6 @@ keywords:
 - authentication
 - google
 - github
-deprecated: true
 sources:
 - https://github.com/pusher/oauth2_proxy
 engine: gotpl

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.5
+version: 3.2.6
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,175 @@
+# ⚠️ Repo Archive Notice
+
+As of Nov 13, 2020, charts in this repo will no longer be updated.
+For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
+
+# oauth2-proxy
+
+[oauth2-proxy](https://github.com/pusher/oauth2_proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
+
+## DEPRECATION NOTICE
+
+This chart is deprecated and no longer supported.
+
+## TL;DR;
+
+```console
+$ helm install stable/oauth2-proxy
+```
+
+## Introduction
+
+This chart bootstraps an oauth2-proxy deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install stable/oauth2-proxy --name my-release
+```
+
+The command deploys oauth2-proxy on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### To 1.0.0
+
+This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/pusher/oauth2_proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
+
+### To 2.0.0
+
+Version 2.0.0 of this chart introduces support for Kubernetes v1.16.x by way of addressing the deprecation of the Deployment object apiVersion `apps/v1beta2`.  See [the v1.16 API deprecations page](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) for more information.
+
+Due to [this issue](https://github.com/helm/helm/issues/6583) there may be errors performing a `helm upgrade`of this chart from versions earlier than 2.0.0.
+
+### To 3.0.0
+
+Version 3.0.0 introduces support for [EKS IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) by adding a managed service account to the chart.  This is a breaking change since the service account is enabled by default.  To disable this behaviour set `serviceAccount.enabled` to `false`
+
+## Configuration
+
+The following table lists the configurable parameters of the oauth2-proxy chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`affinity` | node/pod affinities | None
+`authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
+`authenticatedEmailsFile.template` | Name of the configmap that is handled outside of that chart | `""`
+`authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config | `""`
+`config.clientID` | oauth client ID | `""`
+`config.clientSecret` | oauth client secret | `""`
+`config.cookieSecret` | server specific cookie for the secret; create a new one with `openssl rand -base64 32 | head -c 32 | base64` | `""`
+`config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `nil`
+`config.configFile` | custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
+`config.existingConfig` | existing Kubernetes configmap to use for the configuration file. See [config template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/configmap.yaml) for the required values | `nil`
+`config.google.adminEmail` | user impersonated by the google service account | `""`
+`config.google.serviceAccountJson` | google service account json contents | `""`
+`config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
+`extraArgs` | key:value list of extra arguments to give the binary | `{}`
+`extraEnv` | key:value list of extra environment variables to give the binary | `[]`
+`extraVolumes` | list of extra volumes | `[]`
+`extraVolumeMounts` | list of extra volumeMounts | `[]`
+`htpasswdFile.enabled` | enable htpasswd-file option | `false`
+`htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options) | `{}`
+`htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file | `""`
+`httpScheme` | `http` or `https`. `name` used for port on the deployment. `httpGet` port `name` and `scheme` used for `liveness`- and `readinessProbes`. `name` and `targetPort` used for the service. | `http`
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`image.repository` | Image repository | `quay.io/pusher/oauth2_proxy`
+`image.tag` | Image tag | `v5.1.0`
+`imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
+`ingress.enabled` | Enable Ingress | `false`
+`ingress.path` | Ingress accepted path | `/`
+`ingress.extraPaths` | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`
+`ingress.annotations` | Ingress annotations | `nil`
+`ingress.hosts` | Ingress accepted hostnames | `nil`
+`ingress.tls` | Ingress TLS configuration | `nil`
+`livenessProbe.enabled`  | enable Kubernetes livenessProbe. Disable to use oauth2-proxy with Istio mTLS. See [Istio FAQ](https://istio.io/help/faq/security/#k8s-health-checks) | `true`
+`livenessProbe.initialDelaySeconds` | number of seconds | 0
+`livenessProbe.timeoutSeconds` | number of seconds | 1
+`nodeSelector` | node labels for pod assignment | `{}`
+`podAnnotations` | annotations to add to each pod | `{}`
+`podLabels` | additional labesl to add to each pod | `{}`
+`podDisruptionBudget.enabled`| Enabled creation of PodDisruptionBudget (only if replicaCount > 1) | true
+`podDisruptionBudget.minAvailable`| minAvailable parameter for PodDisruptionBudget | 1
+`podSecurityContext` | Kubernetes security context to apply to pod | `{}`
+`priorityClassName` | priorityClassName | `nil`
+`readinessProbe.enabled` | enable Kubernetes readinessProbe. Disable to use oauth2-proxy with Istio mTLS. See [Istio FAQ](https://istio.io/help/faq/security/#k8s-health-checks) | `true`
+`readinessProbe.initialDelaySeconds` | number of seconds | 0
+`readinessProbe.timeoutSeconds` | number of seconds | 1
+`readinessProbe.periodSeconds` | number of seconds | 10
+`readinessProbe.successThreshold` | number of successes | 1
+`replicaCount` | desired number of pods | `1`
+`resources` | pod resource requests & limits | `{}`
+`service.port` | port for the service | `80`
+`service.type` | type of service | `ClusterIP`
+`service.clusterIP` | cluster ip address | `nil`
+`service.loadBalancerIP` | ip of load balancer | `nil`
+`service.loadBalancerSourceRanges` | allowed source ranges in load balancer | `nil`
+`serviceAccount.enabled` | create a service account | `true`
+`serviceAccount.name` | the service account name | ``
+`serviceAccount.annotations` | (optional) annotations for the service account | `{}`
+`tolerations` | list of node taints to tolerate | `[]`
+`securityContext.enabled` | enable Kubernetes security context on container | `false`
+`securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
+`proxyVarsAsSecrets` | choose between environment values or secrets for setting up OAUTH2_PROXY variables. When set to false, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `true`
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install stable/oauth2-proxy --name my-release \
+  --set=image.tag=v0.0.2,resources.limits.cpu=200m
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/oauth2-proxy --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## SSL Configuration
+
+See: [SSL Configuration](https://pusher.github.io/oauth2_proxy/tls-configuration).
+Use ```values.yaml``` like:
+
+```yaml
+...
+extraArgs:
+  tls-cert: /path/to/cert.pem
+  tls-key: /path/to/cert.key
+
+extraVolumes:
+  - name: ssl-cert
+    secret:
+      secretName: my-ssl-secret
+
+extraVolumeMounts:
+  - mountPath: /path/to/
+    name: ssl-cert
+...
+```
+
+With a secret called `my-ssl-secret`:
+
+```yaml
+...
+data:
+  cert.pem: AB..==
+  cert.key: CD..==
+```

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,15 +1,6 @@
-# ⚠️ Repo Archive Notice
-
-As of Nov 13, 2020, charts in this repo will no longer be updated.
-For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
-
 # oauth2-proxy
 
 [oauth2-proxy](https://github.com/pusher/oauth2_proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
-
-## DEPRECATION NOTICE
-
-This chart is deprecated and no longer supported.
 
 ## TL;DR;
 

--- a/chart/ci/default-values.yaml
+++ b/chart/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/chart/ci/ingress-extra-paths-values.yaml
+++ b/chart/ci/ingress-extra-paths-values.yaml
@@ -1,0 +1,6 @@
+ingress:
+  extraPaths:
+  - path: /*
+    backend:
+      serviceName: ssl-redirect
+      servicePort: use-annotation

--- a/chart/ci/pdb-values.yaml
+++ b/chart/ci/pdb-values.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2  # Enables PodDisruptionBudget which is disabled when replicaCount is 1

--- a/chart/ci/pod-security-context-values.yaml
+++ b/chart/ci/pod-security-context-values.yaml
@@ -1,0 +1,4 @@
+# Allocate a FSGroup that owns the pod’s volumes via podSecurityContext
+---
+podSecurityContext:
+  fsGroup: 2000

--- a/chart/default-values.yaml
+++ b/chart/default-values.yaml
@@ -1,1 +1,0 @@
-# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/chart/default-values.yaml
+++ b/chart/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/chart/pdb-values.yaml
+++ b/chart/pdb-values.yaml
@@ -1,2 +1,0 @@
-# Will trigger creation of pdb
-replicaCount: 2

--- a/chart/pdb-values.yaml
+++ b/chart/pdb-values.yaml
@@ -1,0 +1,2 @@
+# Will trigger creation of pdb
+replicaCount: 2

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that oauth2-proxy has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "oauth2-proxy.fullname" . }}"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oauth2-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oauth2-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oauth2-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Get the secret name.
+*/}}
+{{- define "oauth2-proxy.secretName" -}}
+{{- if .Values.config.existingSecret -}}
+{{- printf "%s" .Values.config.existingSecret -}}
+{{- else -}}
+{{- printf "%s" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "oauth2-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.enabled -}}
+    {{ default (include "oauth2-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/configmap-authenticated-emails-file.yaml
+++ b/chart/templates/configmap-authenticated-emails-file.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.authenticatedEmailsFile.enabled }}
+{{- if .Values.authenticatedEmailsFile.restricted_access }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}-accesslist
+data:
+  restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | quote }}
+{{- end }}
+{{- end }}

--- a/chart/templates/configmap-htpasswd-file.yaml
+++ b/chart/templates/configmap-htpasswd-file.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.htpasswdFile.enabled (not .Values.htpasswdFile.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}-htpasswd-file
+type: Opaque
+stringData:
+  users.txt: |-
+    {{- range $entries := .Values.htpasswdFile.entries }}
+    {{ $entries }}
+    {{- end -}}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.config.existingConfig }}
+{{- if .Values.config.configFile }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+data:
+  oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
+{{- end }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,206 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "oauth2-proxy.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config-emails: {{ include (print $.Template.BasePath "/configmap-authenticated-emails-file.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/google-secret: {{ include (print $.Template.BasePath "/google-secret.yaml") . | sha256sum }}
+{{- if .Values.htpasswdFile.enabled }}
+        checksum/htpasswd: {{ include (print $.Template.BasePath "/configmap-htpasswd-file.yaml") . | sha256sum }}
+{{- end }}
+    {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: {{ template "oauth2-proxy.name" . }}
+        release: "{{ .Release.Name }}"
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+    spec:
+    {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+    {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "oauth2-proxy.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - --http-address=0.0.0.0:4180
+        {{- range $key, $value := .Values.extraArgs }}
+          {{- if $value }}
+          - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
+        {{- end }}
+        {{- if or .Values.config.existingConfig .Values.config.configFile }}
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        {{- end }}
+        {{- if .Values.authenticatedEmailsFile.enabled }}
+        {{- if .Values.authenticatedEmailsFile.template }}
+          - --authenticated-emails-file=/etc/oauth2-proxy/{{ .Values.authenticatedEmailsFile.template }}
+        {{- else }}
+          - --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails-list
+        {{- end }}
+        {{- end }}
+        {{- with .Values.config.google }}
+        {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
+          - --google-admin-email={{ .adminEmail }}
+          - --google-service-account-json=/google/service-account.json
+        {{- end }}
+        {{- end }}
+        {{- if .Values.htpasswdFile.enabled }}
+          - --htpasswd-file=/etc/oauth2_proxy/htpasswd/users.txt
+        {{- end }}
+        env:
+        {{- if .Values.proxyVarsAsSecrets }}
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  {{ template "oauth2-proxy.secretName" . }}
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  {{ template "oauth2-proxy.secretName" . }}
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  {{ template "oauth2-proxy.secretName" . }}
+              key: cookie-secret
+        {{- end }}
+        {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+        {{- end }}
+        ports:
+          - containerPort: 4180
+            name: {{ .Values.httpScheme }}
+            protocol: TCP
+{{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: {{ .Values.httpScheme }}
+            scheme: {{ .Values.httpScheme | upper }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: {{ .Values.httpScheme }}
+            scheme: {{ .Values.httpScheme | upper }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+{{- with .Values.config.google }}
+{{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
+        - name: google-secret
+          mountPath: /google
+          readOnly: true
+{{- end }}
+{{- end }}
+{{- if or .Values.config.existingConfig .Values.config.configFile }}
+        - mountPath: /etc/oauth2_proxy
+          name: configmain
+{{- end }}
+{{- if .Values.authenticatedEmailsFile.enabled }}
+        - mountPath: /etc/oauth2-proxy
+          name: configaccesslist
+          readOnly: true
+{{- end }}
+{{- if .Values.htpasswdFile.enabled }}
+        - mountPath: /etc/oauth2_proxy/htpasswd
+          name: {{ template "oauth2-proxy.fullname" . }}-htpasswd-file
+          readOnly: true
+{{- end }}
+{{- if ne (len .Values.extraVolumeMounts) 0 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+{{- end}}
+      volumes:
+{{- with .Values.config.google }}
+{{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
+      - name: google-secret
+        secret:
+          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.secretName" $ }}{{ end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.htpasswdFile.enabled }}
+      - name: {{ template "oauth2-proxy.fullname" . }}-htpasswd-file
+        secret:
+          secretName: {{ if .Values.htpasswdFile.existingSecret }}{{ .Values.htpasswdFile.existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" . }}-htpasswd-file {{ end }}
+{{- end }}
+
+{{- if or .Values.config.existingConfig .Values.config.configFile }}
+      - configMap:
+          defaultMode: 420
+          name: {{ if .Values.config.existingConfig }}{{ .Values.config.existingConfig }}{{ else }}{{ template "oauth2-proxy.fullname" . }}{{ end }}
+        name: configmain
+{{- end }}
+{{- if ne (len .Values.extraVolumes) 0 }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+{{- if .Values.authenticatedEmailsFile.enabled }}
+      - configMap:
+{{- if .Values.authenticatedEmailsFile.template }}
+          name: {{ .Values.authenticatedEmailsFile.template }}
+{{- else }}
+          name: {{ template "oauth2-proxy.fullname" . }}-accesslist
+{{- end }}
+          items:
+          - key: restricted_user_access
+{{- if .Values.authenticatedEmailsFile.template }}
+            path: {{ .Values.authenticatedEmailsFile.template }}
+{{- else }}
+            path: authenticated-emails-list
+{{- end }}
+        name: configaccesslist
+{{- end }}
+
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}

--- a/chart/templates/google-secret.yaml
+++ b/chart/templates/google-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.config.google (not .Values.config.google.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}-google
+type: Opaque
+data:
+  service-account.json: {{ .serviceAccountJson }}
+{{- end -}}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "oauth2-proxy.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $extraPaths := .Values.ingress.extraPaths -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+{{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/chart/templates/poddisruptionbudget.yaml
+++ b/chart/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "oauth2-proxy.name" . }}
+      release: {{ .Release.Name }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and (not .Values.config.existingSecret) (.Values.proxyVarsAsSecrets) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+type: Opaque
+data:
+  cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
+  client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
+  client-id: {{ .Values.config.clientID | b64enc | quote }}
+{{- end -}}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.httpScheme }}
+      protocol: TCP
+      name: {{ .Values.httpScheme }}
+  selector:
+    app: {{ template "oauth2-proxy.name" . }}
+    release: {{ .Release.Name }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if or .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,184 @@
+# Oauth client configuration specifics
+config:
+  # OAuth client ID
+  clientID: "XXXXXXX"
+  # OAuth client secret
+  clientSecret: "XXXXXXXX"
+  # Create a new secret with the following command
+  # openssl rand -base64 32 | head -c 32 | base64
+  # Use an existing secret for OAuth2 credentials (see secret.yaml for required fields)
+  # Example:
+  # existingSecret: secret
+  cookieSecret: "XXXXXXXXXX"
+  google: {}
+    # adminEmail: xxxx
+    # serviceAccountJson: xxxx
+    # Alternatively, use an existing secret (see google-secret.yaml for required fields)
+    # Example:
+    # existingSecret: google-secret
+  # Default configuration, to be overridden
+  configFile: |-
+    email_domains = [ "*" ]
+    upstreams = [ "file:///dev/null" ]
+  # Custom configuration file: oauth2_proxy.cfg
+  # configFile: |-
+  #   pass_basic_auth = false
+  #   pass_access_token = true
+  # Use an existing config map (see configmap.yaml for required fields)
+  # Example:
+  # existingConfig: config
+
+image:
+  repository: "quay.io/pusher/oauth2_proxy"
+  tag: "v5.1.0"
+  pullPolicy: "IfNotPresent"
+
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+  # - name: myRegistryKeySecretName
+
+extraArgs: {}
+extraEnv: []
+
+# To authorize individual email addresses
+# That is part of extraArgs but since this needs special treatment we need to do a separate section
+authenticatedEmailsFile:
+  enabled: false
+  # template is the name of the configmap what contains the email user list but has been configured without this chart.
+  # It's a simpler way to maintain only one configmap (user list) instead changing it for each oauth2-proxy service.
+  # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access".
+  template: ""
+  # One email per line
+  # example:
+  # restricted_access: |-
+  #   name1@domain
+  #   name2@domain
+  # If you override the config with restricted_access it will configure a user list within this chart what takes care of the
+  # config map resource.
+  restricted_access: ""
+
+service:
+  type: ClusterIP
+  # when service.type is ClusterIP ...
+  # clusterIP: 192.0.2.20
+  # when service.type is LoadBalancer ...
+  # loadBalancerIP: 198.51.100.40
+  # loadBalancerSourceRanges: 203.0.113.0/24
+  port: 80
+  annotations: {}
+  # foo.io/bar: "true"
+
+## Create or use ServiceAccount
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  enabled: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name:
+  annotations: {}
+
+ingress:
+  enabled: false
+  path: /
+  # Used to create an Ingress record.
+  # hosts:
+    # - chart-example.local
+  # Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  # extraPaths:
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+  # tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
+extraVolumes: []
+  # - name: ca-bundle-cert
+  #   secret:
+  #     secretName: <secret-name>
+
+extraVolumeMounts: []
+  # - mountPath: /etc/ssl/certs/
+  #   name: ca-bundle-cert
+
+priorityClassName: ""
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# Whether to use secrets instead of environment values for setting up OAUTH2_PROXY variables
+proxyVarsAsSecrets: true
+
+# Configure Kubernetes liveness and readiness probes.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+# Disable both when deploying with Istio 1.0 mTLS. https://istio.io/help/faq/security/#k8s-health-checks
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  periodSeconds: 10
+  successThreshold: 1
+
+# Configure Kubernetes security context for container
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  enabled: false
+  runAsNonRoot: true
+
+podAnnotations: {}
+podLabels: {}
+replicaCount: 1
+
+## PodDisruptionBudget settings
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Configure Kubernetes security context for pod
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
+# whether to use http or https
+httpScheme: http
+
+# Additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption.
+# Alternatively supply an existing secret which contains the required information.
+htpasswdFile:
+  enabled: false
+  existingSecret: ""
+  entries: {}
+  # One row for each user
+  # example:
+  # entries:
+  #  - testuser:{SHA}EWhzdhgoYJWy0z2gyzhRYlN9DSiv

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+chart-dirs:
+  - ./
+target-branch: main
+helm-extra-args: --timeout 600s
+


### PR DESCRIPTION
- Chart history migrated to the new repository by @JoelSpeed 
- Apache license taken from helm/stable repo
- pipelines based on [helm/charts-repo-actions-demo](https://github.com/helm/charts-repo-actions-demo)
  - same linting tool as used by helm/stable repo
  - successfully ran `ct lint` and `ct install` locally (see readme in this PR on how to do this)

If merged to the main branch this should get us a gh-pages hosted helm chart running the same validations as before.

I'm using my fork to test if the workflows work as intended. Will report if successful.