### PR TITLE
Fix charts_dir in chart releaser action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         with:
-          charts_dir: charts
+          charts_dir: chart
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The chart release action did not work when we merged #1, I believe this is due to the directory not being correct.

```
Looking up latest tag...
Discovering changed charts since '5199dbeeac8cd3d86ca56a5f82375f32bf540f6d'...
Nothing to do. No chart changes detected.
```

CC @erkannt could you please review?