### PR TITLE
Include the redis sub-chart dependency

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: oauth2-proxy
 version: 3.2.7
-apiVersion: v1
+apiVersion: v2
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
@@ -12,7 +12,7 @@ keywords:
 - google
 - github
 - redis
-dependencies: 
+dependencies:
   - name: redis
     version: ~10.6.0
     repository: https://charts.bitnami.com/bitnami

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.7
+version: 3.2.8
 apiVersion: v2
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.6
+version: 3.2.7
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -11,6 +11,13 @@ keywords:
 - authentication
 - google
 - github
+- redis
+dependencies: 
+  - name: redis
+    version: ~10.6.0
+    repository: https://charts.bitnami.com/bitnami
+    alias: redis
+    condition: redis.enabled
 sources:
 - https://github.com/oauth2-proxy/oauth2-proxy
 - https://github.com/oauth2-proxy/manifests

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -117,6 +117,16 @@ Parameter | Description | Default
 `securityContext.enabled` | enable Kubernetes security context on container | `false`
 `securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
 `proxyVarsAsSecrets` | choose between environment values or secrets for setting up OAUTH2_PROXY variables. When set to false, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `true`
+`sessionStorage.cookie.enabled` | enable cookie based session storage | `true`
+`sessionStorage.redis.enabled` | enable redis session storage | `false`
+`sessionStorage.redis.password` | Redis password. Applicable for all Redis configurations | `nil`
+`sessionStorage.redis.clientType` | Allows the user to select which type of client will be used for redis instance. Possible options are: `sentinel`, `cluster` or `standalone` | `standalone`
+`sessionStorage.redis.standalone.connectionUrl` | URL of redis standalone server for redis session storage (e.g. redis://HOST[:PORT]) | `nil`
+`sessionStorage.redis.cluster.connectionUrls` | List of Redis cluster connection URLs (e.g. redis://HOST[:PORT]) | `[]`
+`sessionStorage.redis.sentinel.password` | Redis sentinel password. Used only for sentinel connection; any redis node passwords need to use `sessionStorage.redis.password` | `nil`
+`sessionStorage.redis.sentinel.masterName` | Redis sentinel master name | `nil`
+`sessionStorage.redis.sentinel.connectionUrls` | List of Redis sentinel connection URLs (e.g. redis://HOST[:PORT]) | `[]`
+`redis.enabled` | Enable the redis subchart deployment | `false`
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -117,8 +117,7 @@ Parameter | Description | Default
 `securityContext.enabled` | enable Kubernetes security context on container | `false`
 `securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
 `proxyVarsAsSecrets` | choose between environment values or secrets for setting up OAUTH2_PROXY variables. When set to false, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `true`
-`sessionStorage.cookie.enabled` | enable cookie based session storage | `true`
-`sessionStorage.redis.enabled` | enable redis session storage | `false`
+`sessionStorage.type` | Session storage type which can be one of the following: cookie or redis | `cookie`
 `sessionStorage.redis.password` | Redis password. Applicable for all Redis configurations | `nil`
 `sessionStorage.redis.clientType` | Allows the user to select which type of client will be used for redis instance. Possible options are: `sentinel`, `cluster` or `standalone` | `standalone`
 `sessionStorage.redis.standalone.connectionUrl` | URL of redis standalone server for redis session storage (e.g. redis://HOST[:PORT]) | `nil`

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -118,6 +118,7 @@ Parameter | Description | Default
 `securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
 `proxyVarsAsSecrets` | choose between environment values or secrets for setting up OAUTH2_PROXY variables. When set to false, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `true`
 `sessionStorage.type` | Session storage type which can be one of the following: cookie or redis | `cookie`
+`sessionStorage.redis.existingSecret` | existing Kubernetes secret to use for redis-password and redis-sentinel-password | `""`
 `sessionStorage.redis.password` | Redis password. Applicable for all Redis configurations | `nil`
 `sessionStorage.redis.clientType` | Allows the user to select which type of client will be used for redis instance. Possible options are: `sentinel`, `cluster` or `standalone` | `standalone`
 `sessionStorage.redis.standalone.connectionUrl` | URL of redis standalone server for redis session storage (e.g. redis://HOST[:PORT]) | `nil`

--- a/helm/oauth2-proxy/ci/redis-standalone-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-standalone-values.yaml
@@ -1,0 +1,9 @@
+sessionStorage:
+  type: redis
+  redis:
+    clientType: "standalone"
+    standalone:
+      connectionUrl: "redis://oauth2-proxy-redis-master:6379"
+redis:
+  # provision an instance of the redis sub-chart
+  enabled: true

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         checksum/config-emails: {{ include (print $.Template.BasePath "/configmap-authenticated-emails-file.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         checksum/google-secret: {{ include (print $.Template.BasePath "/google-secret.yaml") . | sha256sum }}
+        checksum/redis-secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
 {{- if .Values.htpasswdFile.enabled }}
         checksum/htpasswd: {{ include (print $.Template.BasePath "/configmap-htpasswd-file.yaml") . | sha256sum }}
 {{- end }}
@@ -70,23 +71,6 @@ spec:
           - --google-service-account-json=/google/service-account.json
         {{- end }}
         {{- end }}
-        {{- if eq (default "cookie" .Values.sessionStorage.type) "redis" }}
-          - --session-store-type=redis
-        {{- if .Values.sessionStorage.redis.password }}
-          - --redis-password={{ .Values.sessionStorage.redis.password }}
-        {{- end }}
-        {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}
-          - --redis-connection-url={{ .Values.sessionStorage.redis.standalone.connectionUrl }}
-        {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "cluster" }}
-          - --redis-use-cluster=true
-          - --redis-cluster-connection-urls={{ .Values.sessionStorage.redis.cluster.connectionUrls }}
-        {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "sentinel" }}
-          - --redis-use-sentinel=true
-          - --redis-sentinel-master-name={{ .Values.sessionStorage.redis.sentinel.masterName }}
-          - --redis-sentinel-connection-urls={{ .Values.sessionStorage.redis.sentinel.connectionUrls }}
-          - --redis-sentinel-password={{ .Values.sessionStorage.redis.sentinel.password }}
-        {{- end }}
-        {{- end }}
         {{- if .Values.htpasswdFile.enabled }}
           - --htpasswd-file=/etc/oauth2_proxy/htpasswd/users.txt
         {{- end }}
@@ -107,6 +91,40 @@ spec:
             secretKeyRef:
               name:  {{ template "oauth2-proxy.secretName" . }}
               key: cookie-secret
+        {{- end }}
+        {{- if eq (default "cookie" .Values.sessionStorage.type) "redis" }}
+        - name: OAUTH2_PROXY_SESSION_STORE_TYPE
+          value: "redis"
+        {{- if .Values.sessionStorage.redis.password }}
+        - name: OAUTH2_PROXY_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name:  {{ template "oauth2-proxy.fullname" . }}-redis
+              key: redis-password
+        {{- end }}
+        {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}
+        - name: OAUTH2_PROXY_REDIS_CONNECTION_URL
+          value: {{ .Values.sessionStorage.redis.standalone.connectionUrl }}
+        {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "cluster" }}
+        - name: OAUTH2_PROXY_REDIS_USE_CLUSTER
+          value: "true"
+        - name: OAUTH2_PROXY_REDIS_CLUSTER_CONNECTION_URLS
+          value: {{ .Values.sessionStorage.redis.cluster.connectionUrls }}
+        {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "sentinel" }}
+        - name: OAUTH2_PROXY_REDIS_USE_SENTINEL
+          value: "true"
+        - name: OAUTH2_PROXY_REDIS_SENTINEL_MASTER_NAME
+          value: {{ .Values.sessionStorage.redis.sentinel.masterName }}
+        - name: OAUTH2_PROXY_REDIS_SENTINEL_CONNECTION_URLS
+          value: {{ .Values.sessionStorage.redis.sentinel.connectionUrls }}
+        {{- if .Values.sessionStorage.redis.sentinel.password }}
+        - name: OAUTH2_PROXY_REDIS_SENTINEL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ if .Values.sessionStorage.redis.existingSecret }} {{ .Values.sessionStorage.redis.existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" . }}-redis{{ end }}
+              key: redis-sentinel-password
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -70,6 +70,23 @@ spec:
           - --google-service-account-json=/google/service-account.json
         {{- end }}
         {{- end }}
+        {{- if eq (default "cookie" .Values.sessionStorage.type) "redis" }}
+          - --session-store-type=redis
+        {{- if .Values.sessionStorage.redis.password }}
+          - --redis-password={{ .Values.sessionStorage.redis.password }}
+        {{- end }}
+        {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}
+          - --redis-connection-url={{ .Values.sessionStorage.redis.standalone.connectionUrl }}
+        {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "cluster" }}
+          - --redis-use-cluster=true
+          - --redis-cluster-connection-urls={{ .Values.sessionStorage.redis.cluster.connectionUrls }}
+        {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "sentinel" }}
+          - --redis-use-sentinel=true
+          - --redis-sentinel-master-name={{ .Values.sessionStorage.redis.sentinel.masterName }}
+          - --redis-sentinel-connection-urls={{ .Values.sessionStorage.redis.sentinel.connectionUrls }}
+          - --redis-sentinel-password={{ .Values.sessionStorage.redis.sentinel.password }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.htpasswdFile.enabled }}
           - --htpasswd-file=/etc/oauth2_proxy/htpasswd/users.txt
         {{- end }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
         - name: OAUTH2_PROXY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.fullname" . }}-redis
+              name:  {{ template "oauth2-proxy.fullname" . }}-redis-access
               key: redis-password
         {{- end }}
         {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}
@@ -121,7 +121,7 @@ spec:
         - name: OAUTH2_PROXY_REDIS_SENTINEL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ if .Values.sessionStorage.redis.existingSecret }} {{ .Values.sessionStorage.redis.existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" . }}-redis{{ end }}
+              name: {{ if .Values.sessionStorage.redis.existingSecret }} {{ .Values.sessionStorage.redis.existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" . }}-redis-access{{ end }}
               key: redis-sentinel-password
         {{- end }}
         {{- end }}

--- a/helm/oauth2-proxy/templates/redis-secret.yaml
+++ b/helm/oauth2-proxy/templates/redis-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and (eq .Values.sessionStorage.type "redis") (not .Values.sessionStorage.redis.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}-redis
+type: Opaque
+data:
+  redis-password: {{ .Values.sessionStorage.redis.password | b64enc | quote }}
+  redis-sentinel-password: {{ .Values.sessionStorage.redis.sentinel.password | b64enc | quote }}
+{{- end -}}

--- a/helm/oauth2-proxy/templates/redis-secret.yaml
+++ b/helm/oauth2-proxy/templates/redis-secret.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "oauth2-proxy.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "oauth2-proxy.fullname" . }}-redis
+  name: {{ template "oauth2-proxy.fullname" . }}-redis-access
 type: Opaque
 data:
   redis-password: {{ .Values.sessionStorage.redis.password | b64enc | quote }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -194,10 +194,12 @@ sessionStorage:
     standalone:
       connectionUrl: ""
     cluster:
+      # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]
       connectionUrls: []
     sentinel:
       password: ""
       masterName: ""
+      # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]
       connectionUrls:	[]
 
 # Enables and configure the automatic deployment of the redis subchart

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -202,7 +202,7 @@ sessionStorage:
       password: ""
       masterName: ""
       # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]
-      connectionUrls:	[]
+      connectionUrls: []
 
 # Enables and configure the automatic deployment of the redis subchart
 redis:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -188,6 +188,8 @@ sessionStorage:
   # Can be one of the supported session storage cookie/redis
   type: cookie
   redis:
+    # Secret name that holds the redis-password and redis-sentinel-password values
+    existingSecret: ""
     password: ""
     # Can be one of sentinel/cluster/standalone
     clientType: "standalone"

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -185,10 +185,9 @@ htpasswdFile:
 
 # Configure the session storage type, between cookie and redis
 sessionStorage:
-  cookie:
-    enabled: true
-  redis: 
-    enabled: false 
+  # Can be one of the supported session storage cookie/redis
+  type: cookie
+  redis:
     password: ""
     # Can be one of sentinel/cluster/standalone
     clientType: "standalone"
@@ -196,19 +195,18 @@ sessionStorage:
       connectionUrl: ""
     cluster:
       connectionUrls: []
-    sentinel: 
+    sentinel:
       password: ""
       masterName: ""
       connectionUrls:	[]
 
-# Enables and configure the automatic deployment of the redis subchart 
-redis: 
+# Enables and configure the automatic deployment of the redis subchart
+redis:
   # provision an instance of the redis sub-chart
   enabled: false
-  # Redis specific helm chart settings, please see: 
+  # Redis specific helm chart settings, please see:
   # https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters
   # redisPort: 6379
   # cluster:
   #   enabled: false
   #   slaveCount: 1
-

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -182,3 +182,33 @@ htpasswdFile:
   # example:
   # entries:
   #  - testuser:{SHA}EWhzdhgoYJWy0z2gyzhRYlN9DSiv
+
+# Configure the session storage type, between cookie and redis
+sessionStorage:
+  cookie:
+    enabled: true
+  redis: 
+    enabled: false 
+    password: ""
+    # Can be one of sentinel/cluster/standalone
+    clientType: "standalone"
+    standalone:
+      connectionUrl: ""
+    cluster:
+      connectionUrls: []
+    sentinel: 
+      password: ""
+      masterName: ""
+      connectionUrls:	[]
+
+# Enables and configure the automatic deployment of the redis subchart 
+redis: 
+  # provision an instance of the redis sub-chart
+  enabled: false
+  # Redis specific helm chart settings, please see: 
+  # https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters
+  # redisPort: 6379
+  # cluster:
+  #   enabled: false
+  #   slaveCount: 1
+


### PR DESCRIPTION
Defines the options available for the end-user's configuration with redis session storage. 
In our own helm chart we had it simplified for our standalone type of redis client. However oauth2-proxy image support more than just our case.  