### PR TITLE
fix: point chart releaser charts_dir at helm dir

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,5 +26,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
+        with:
+          charts_dir: helm
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Findings from my fork:

- `ct.yaml` is only meant for `chart-Tester` :doh:
- `chart-releaser` `charts_dir` works without `./` (good spot @JoelSpeed)
- `ct.yaml` on the  other hand requires the `./` to be present

:pray: hope this finally gets us a release. Sorry about all the hitches.