### PR TITLE
Support to persist the configaccesslist as a secret also

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.6
+version: 3.2.8
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.8
+version: 3.2.7
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -62,6 +62,7 @@ Parameter | Description | Default
 `authenticatedEmailsFile.persistence` | Defines how the email addresses file will be projected, via a configmap or secret | `configmap`
 `authenticatedEmailsFile.template` | Name of the configmap that is handled outside of that chart | `""`
 `authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config | `""`
+`authenticatedEmailsFile.annotations` | configmap or secret annotations | `nil`
 `config.clientID` | oauth client ID | `""`
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `openssl rand -base64 32 | head -c 32 | base64` | `""`

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -60,7 +60,7 @@ Parameter | Description | Default
 `affinity` | node/pod affinities | None
 `authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
 `authenticatedEmailsFile.persistence` | Defines how the email addresses file will be projected, via a configmap or secret | `configmap`
-`authenticatedEmailsFile.template` | Name of the configmap that is handled outside of that chart | `""`
+`authenticatedEmailsFile.template` | Name of the configmap or secret that is handled outside of that chart | `""`
 `authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config | `""`
 `authenticatedEmailsFile.annotations` | configmap or secret annotations | `nil`
 `config.clientID` | oauth client ID | `""`

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -59,6 +59,7 @@ Parameter | Description | Default
 --- | --- | ---
 `affinity` | node/pod affinities | None
 `authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
+`authenticatedEmailsFile.persistence` | Defines how the email addresses file will be projected, via a configmap or secret | `configmap`
 `authenticatedEmailsFile.template` | Name of the configmap that is handled outside of that chart | `""`
 `authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config | `""`
 `config.clientID` | oauth client ID | `""`

--- a/helm/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
+++ b/helm/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
@@ -8,9 +8,11 @@ metadata:
     chart: {{ template "oauth2-proxy.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "oauth2-proxy.fullname" . }}-accesslist
+{{- if .Values.authenticatedEmailsFile.annotations }}
   annotations:
-    "helm.sh/resource-policy": keep
+{{ toYaml .Values.authenticatedEmailsFile.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "oauth2-proxy.fullname" . }}-accesslist
 data:
   restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | quote }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -164,6 +164,23 @@ spec:
           secretName: {{ if .Values.htpasswdFile.existingSecret }}{{ .Values.htpasswdFile.existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" . }}-htpasswd-file {{ end }}
 {{- end }}
 
+{{- if and (.Values.authenticatedEmailsFile.enabled) (eq .Values.authenticatedEmailsFile.persistence "secret") }}
+      - name: configaccesslist
+        secret: 
+          items:
+          - key: restricted_user_access
+{{- if .Values.authenticatedEmailsFile.template }}
+            path: {{ .Values.authenticatedEmailsFile.template }}
+{{- else }}
+            path: authenticated-emails-list
+{{- end }}
+{{- if .Values.authenticatedEmailsFile.template }}
+          secretName: {{ .Values.authenticatedEmailsFile.template }}
+{{- else }}
+          secretName: {{ template "oauth2-proxy.fullname" . }}-accesslist
+{{- end }}
+{{- end }}
+
 {{- if or .Values.config.existingConfig .Values.config.configFile }}
       - configMap:
           defaultMode: 420
@@ -173,7 +190,7 @@ spec:
 {{- if ne (len .Values.extraVolumes) 0 }}
 {{ toYaml .Values.extraVolumes | indent 6 }}
 {{- end }}
-{{- if .Values.authenticatedEmailsFile.enabled }}
+{{- if and (.Values.authenticatedEmailsFile.enabled) (eq .Values.authenticatedEmailsFile.persistence "configmap") }}
       - configMap:
 {{- if .Values.authenticatedEmailsFile.template }}
           name: {{ .Values.authenticatedEmailsFile.template }}

--- a/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
+++ b/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.authenticatedEmailsFile.enabled }}
-{{- if and (.Values.authenticatedEmailsFile.restricted_access) (eq .Values.authenticatedEmailsFile.persistence "configmap")  }}
+{{- if and (.Values.authenticatedEmailsFile.restricted_access) (eq .Values.authenticatedEmailsFile.persistence "secret")  }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
+type: Opaque
 metadata:
   labels:
     app: {{ template "oauth2-proxy.name" . }}
@@ -12,6 +13,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
 data:
-  restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | quote }}
+  restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | b64enc }}
 {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
+++ b/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
@@ -9,9 +9,11 @@ metadata:
     chart: {{ template "oauth2-proxy.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "oauth2-proxy.fullname" . }}-accesslist
+{{- if .Values.authenticatedEmailsFile.annotations }}
   annotations:
-    "helm.sh/resource-policy": keep
+{{ toYaml .Values.authenticatedEmailsFile.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "oauth2-proxy.fullname" . }}-accesslist
 data:
   restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | b64enc }}
 {{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -46,6 +46,8 @@ extraEnv: []
 # That is part of extraArgs but since this needs special treatment we need to do a separate section
 authenticatedEmailsFile:
   enabled: false
+  # Defines how the email addresses file will be projected, via a configmap or secret
+  persistence: configmap
   # template is the name of the configmap what contains the email user list but has been configured without this chart.
   # It's a simpler way to maintain only one configmap (user list) instead changing it for each oauth2-proxy service.
   # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access".
@@ -58,6 +60,8 @@ authenticatedEmailsFile:
   # If you override the config with restricted_access it will configure a user list within this chart what takes care of the
   # config map resource.
   restricted_access: ""
+  annotations: {}
+  # helm.sh/resource-policy: keep
 
 service:
   type: ClusterIP


### PR DESCRIPTION
The end-user can now choose to project the email addresses file as a configmap or as a secret. 

There might be solutions/teams (like us) that modify the email address file from outside oauth2-proxy, adding, removing entries as per the business intent. We want to keep the configmap/secret even if somebody will remove the oauth2-proxy release and reuse it. I've added the following policy annotation to retain the 2 k8s resources. 
```yaml
  annotations:
    "helm.sh/resource-policy": keep
```
