### PR TITLE
Configurable cookie name

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.6
+version: 3.2.9
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -67,6 +67,7 @@ Parameter | Description | Default
 `config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `nil`
 `config.configFile` | custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
 `config.existingConfig` | existing Kubernetes configmap to use for the configuration file. See [config template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/configmap.yaml) for the required values | `nil`
+`config.cookieName` | The name of the cookie that oauth2-proxy will create. If let empty, the chart will default it to the release name | `""`
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -67,7 +67,7 @@ Parameter | Description | Default
 `config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `nil`
 `config.configFile` | custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
 `config.existingConfig` | existing Kubernetes configmap to use for the configuration file. See [config template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/configmap.yaml) for the required values | `nil`
-`config.cookieName` | The name of the cookie that oauth2-proxy will create. If let empty, the chart will default it to the release name | `""`
+`config.cookieName` | The name of the cookie that oauth2-proxy will create. | `""`
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -49,8 +49,6 @@ spec:
           - --http-address=0.0.0.0:4180
         {{- if .Values.config.cookieName }}
           - --cookie-name={{ .Values.config.cookieName }}
-        {{- else }}
-          - --cookie-name={{ .Release.Name | replace "-" "_"}}
         {{- end }}
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -47,6 +47,11 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - --http-address=0.0.0.0:4180
+        {{- if .Values.config.cookieName }}
+          - --cookie-name={{ .Values.config.cookieName }}
+        {{- else }}
+          - --cookie-name={{ .Release.Name | replace "-" "_"}}
+        {{- end }}
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
           - --{{ $key }}={{ $value }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -11,7 +11,7 @@ config:
   # existingSecret: secret
   cookieSecret: "XXXXXXXXXX"
   # The name of the cookie that oauth2-proxy will create
-  # If left empty, it will default to the release name 
+  # If left empty, it will default to the release name
   cookieName: ""
   google: {}
     # adminEmail: xxxx

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -10,6 +10,9 @@ config:
   # Example:
   # existingSecret: secret
   cookieSecret: "XXXXXXXXXX"
+  # The name of the cookie that oauth2-proxy will create
+  # If left empty, it will default to the release name 
+  cookieName: ""
   google: {}
     # adminEmail: xxxx
     # serviceAccountJson: xxxx


### PR DESCRIPTION
Exposing the cookie-name in the values file to allow the end-user to configure it, thus raising awareness of it. 
If the end-users needs a specific hard-coded value they can just set the config.cookieName to that specific value.

If left empty it will default to the release name, `{{ .Release.Name | replace "-" "_"}}`.

