### PR TITLE
fix: get chart-testing to lint the charts

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,7 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
 chart-dirs:
-  - ./helm
+  - helm
 target-branch: main
 helm-extra-args: --timeout 600s
 


### PR DESCRIPTION
The config doesn't like the `./` in specifying the charts directory.

Looking at the current actions you can see that the linter is skipping all the directories.

I could repro this locally and got it fixed with the submitted change.

@JoelSpeed 