### PR TITLE
add missing 'list-changed' step to ci workflow

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -28,6 +28,14 @@ jobs:
         with:
           version: v3.3.0
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 


### PR DESCRIPTION
The later cluster setup stage runs based on the output of this step. I must have overlooked that originally and removed this step as we only have a single chart and listing that felt superfluous.

I wonder if it makes sense to add this also to the `release` workflow to avoid failed runs when there is a merge to main that doesn't modify the chart.

Will investigate on a fork and make another PR based on my findings.

This should hopefully fix the failed checks on #18 