### PR TITLE
[PR] Fixed OAUTH2_PROXY_REDIS_PASSWORD env variable

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 3.2.10
+version: 3.2.11
 apiVersion: v2
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
         - name: OAUTH2_PROXY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.fullname" . }}-redis-access
+              name: {{ if .Values.sessionStorage.redis.existingSecret }} {{ .Values.sessionStorage.redis.existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" . }}-redis-access{{ end }}
               key: redis-password
         {{- end }}
         {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}


### PR DESCRIPTION
The chart, even in the presence of `existingSecret`, still used the name of the default secret. 