### PR TITLE
Update oauth2-proxy to 7.1.3 & set default redis url if no one is defined in standalone mode

### DIFF
--- a/helm/oauth2-proxy/Chart.lock
+++ b/helm/oauth2-proxy/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.6.19
+digest: sha256:9967a7f9f35d93e0c3ac69e4cfbea4ea8d38cfd12a7ad416dd81256800eb040f
+generated: "2021-05-14T12:07:28.273068+02:00"

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 3.2.12
+version: 3.3.0
 apiVersion: v2
-appVersion: 5.1.0
+appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -125,7 +125,7 @@ Parameter | Description | Default
 `sessionStorage.redis.existingSecret` | existing Kubernetes secret to use for redis-password and redis-sentinel-password | `""`
 `sessionStorage.redis.password` | Redis password. Applicable for all Redis configurations | `nil`
 `sessionStorage.redis.clientType` | Allows the user to select which type of client will be used for redis instance. Possible options are: `sentinel`, `cluster` or `standalone` | `standalone`
-`sessionStorage.redis.standalone.connectionUrl` | URL of redis standalone server for redis session storage (e.g. redis://HOST[:PORT]) | `nil`
+`sessionStorage.redis.standalone.connectionUrl` | URL of redis standalone server for redis session storage (e.g. redis://HOST[:PORT]). Automatically generated if not set. | `""`
 `sessionStorage.redis.cluster.connectionUrls` | List of Redis cluster connection URLs (e.g. redis://HOST[:PORT]) | `[]`
 `sessionStorage.redis.sentinel.password` | Redis sentinel password. Used only for sentinel connection; any redis node passwords need to use `sessionStorage.redis.password` | `nil`
 `sessionStorage.redis.sentinel.masterName` | Redis sentinel master name | `nil`

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -1,6 +1,6 @@
 # oauth2-proxy
 
-[oauth2-proxy](https://github.com/pusher/oauth2_proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
+[oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
 
 ## TL;DR;
 
@@ -40,7 +40,7 @@ incompatible breaking change needing manual actions.
 
 ### To 1.0.0
 
-This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/pusher/oauth2_proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
+This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/oauth2-proxy/oauth2-proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
 
 ### To 2.0.0
 
@@ -62,13 +62,13 @@ Parameter | Description | Default
 `authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
 `authenticatedEmailsFile.persistence` | Defines how the email addresses file will be projected, via a configmap or secret | `configmap`
 `authenticatedEmailsFile.template` | Name of the configmap or secret that is handled outside of that chart | `""`
-`authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config | `""`
+`authenticatedEmailsFile.restricted_access` | [email addresses](https://github.com/oauth2-proxy/oauth2-proxy#email-authentication) list config | `""`
 `authenticatedEmailsFile.annotations` | configmap or secret annotations | `nil`
 `config.clientID` | oauth client ID | `""`
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `openssl rand -base64 32 | head -c 32 | base64` | `""`
 `config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `nil`
-`config.configFile` | custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
+`config.configFile` | custom [oauth2_proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
 `config.existingConfig` | existing Kubernetes configmap to use for the configuration file. See [config template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/configmap.yaml) for the required values | `nil`
 `config.cookieName` | The name of the cookie that oauth2-proxy will create. | `""`
 `config.google.adminEmail` | user impersonated by the google service account | `""`
@@ -79,12 +79,12 @@ Parameter | Description | Default
 `extraVolumes` | list of extra volumes | `[]`
 `extraVolumeMounts` | list of extra volumeMounts | `[]`
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`
-`htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options) | `{}`
+`htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://oauth2-proxy.github.io/oauth2-proxy/configuration#command-line-options) | `{}`
 `htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file | `""`
 `httpScheme` | `http` or `https`. `name` used for port on the deployment. `httpGet` port `name` and `scheme` used for `liveness`- and `readinessProbes`. `name` and `targetPort` used for the service. | `http`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
-`image.repository` | Image repository | `quay.io/pusher/oauth2_proxy`
-`image.tag` | Image tag | `v5.1.0`
+`image.repository` | Image repository | `quay.io/oauth2-proxy/oauth2-proxy`
+`image.tag` | Image tag | `v7.1.3`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | Enable Ingress | `false`
 `ingress.path` | Ingress accepted path | `/`

--- a/helm/oauth2-proxy/ci/redis-standalone-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-standalone-values.yaml
@@ -7,3 +7,5 @@ sessionStorage:
 redis:
   # provision an instance of the redis sub-chart
   enabled: true
+  cluster:
+    enabled: false

--- a/helm/oauth2-proxy/ci/redis-standalone-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-standalone-values.yaml
@@ -2,10 +2,8 @@ sessionStorage:
   type: redis
   redis:
     clientType: "standalone"
-    standalone:
-      connectionUrl: "redis://oauth2-proxy-redis-master:6379"
+    password: "foo"
 redis:
   # provision an instance of the redis sub-chart
   enabled: true
-  cluster:
-    enabled: false
+  password: "foo"

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -52,3 +52,12 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+
+{{- define "oauth2-proxy.redisStandaloneUrl" -}}
+{{- if .Values.sessionStorage.redis.standalone.connectionUrl -}}
+{{ .Values.sessionStorage.redis.standalone.connectionUrl }}
+{{- else -}}
+{{- printf "redis://%s-redis-master:6379" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
         {{- end }}
         {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}
         - name: OAUTH2_PROXY_REDIS_CONNECTION_URL
-          value: {{ .Values.sessionStorage.redis.standalone.connectionUrl }}
+          value: {{ include "oauth2-proxy.redisStandaloneUrl" . }}
         {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "cluster" }}
         - name: OAUTH2_PROXY_REDIS_USE_CLUSTER
           value: "true"

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -9,7 +9,7 @@ config:
   # Use an existing secret for OAuth2 credentials (see secret.yaml for required fields)
   # Example:
   # existingSecret: secret
-  cookieSecret: "XXXXXXXXXX"
+  cookieSecret: "XXXXXXXXXXXXXXXX"
   # The name of the cookie that oauth2-proxy will create
   # If left empty, it will default to the release name
   cookieName: ""
@@ -32,8 +32,8 @@ config:
   # existingConfig: config
 
 image:
-  repository: "quay.io/pusher/oauth2_proxy"
-  tag: "v5.1.0"
+  repository: "quay.io/oauth2-proxy/oauth2-proxy"
+  tag: "v7.1.3"
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -201,6 +201,7 @@ sessionStorage:
     # Can be one of sentinel/cluster/standalone
     clientType: "standalone"
     standalone:
+      # If empty and sessionStorage type is redis, will automatically be generated.
       connectionUrl: ""
     cluster:
       # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]


### PR DESCRIPTION
Replaces https://github.com/oauth2-proxy/manifests/pull/18