### PR TITLE
Uses template function to generate service account name

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.0.1
+version: 4.0.2
 apiVersion: v2
 appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/serviceaccount.yaml
+++ b/helm/oauth2-proxy/templates/serviceaccount.yaml
@@ -11,5 +11,5 @@ metadata:
     chart: {{ template "oauth2-proxy.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "oauth2-proxy.fullname" . }}
+  name: {{ template "oauth2-proxy.serviceAccountName" . }}
 {{- end -}}


### PR DESCRIPTION
I would like to override the service account name instead use the default full name.

Signed-off-by: Caio Almeida <caio.almeida@gympass.com>