### PR TITLE
Add possibility to specify extra labels

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.0.1
+version: 4.1.0
 apiVersion: v2
 appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -84,6 +84,7 @@ Parameter | Description | Default
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `extraEnv` | key:value list of extra environment variables to give the binary | `[]`
+`extraLabels` | key:value list of extra labels to add to all k8s objects | `{}`
 `extraVolumes` | list of extra volumes | `[]`
 `extraVolumeMounts` | list of extra volumeMounts | `[]`
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -32,6 +32,33 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "oauth2-proxy.labels" -}}
+helm.sh/chart: {{ include "oauth2-proxy.chart" . }}
+chart: {{ template "oauth2-proxy.chart" . }}
+{{ include "oauth2-proxy.selectorLabels" . }}
+app: {{ template "oauth2-proxy.name" . }}
+release: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+heritage: {{ .Release.Service }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oauth2-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oauth2-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Get the secret name.
 */}}
 {{- define "oauth2-proxy.secretName" -}}

--- a/helm/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
+++ b/helm/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
@@ -4,10 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
 {{- if .Values.authenticatedEmailsFile.annotations }}
   annotations:
 {{ toYaml .Values.authenticatedEmailsFile.annotations | indent 4 }}

--- a/helm/oauth2-proxy/templates/configmap-htpasswd-file.yaml
+++ b/helm/oauth2-proxy/templates/configmap-htpasswd-file.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}-htpasswd-file
 type: Opaque
 stringData:

--- a/helm/oauth2-proxy/templates/configmap.yaml
+++ b/helm/oauth2-proxy/templates/configmap.yaml
@@ -4,10 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 data:
   oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -2,17 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "oauth2-proxy.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "oauth2-proxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -28,8 +24,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "oauth2-proxy.name" . }}
-        release: "{{ .Release.Name }}"
+        {{- include "oauth2-proxy.labels" . | nindent 8 }}
       {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
       {{- end }}
@@ -204,7 +199,7 @@ spec:
 
 {{- if and (.Values.authenticatedEmailsFile.enabled) (eq .Values.authenticatedEmailsFile.persistence "secret") }}
       - name: configaccesslist
-        secret: 
+        secret:
           items:
           - key: restricted_user_access
 {{- if .Values.authenticatedEmailsFile.template }}

--- a/helm/oauth2-proxy/templates/google-secret.yaml
+++ b/helm/oauth2-proxy/templates/google-secret.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}-google
 type: Opaque
 data:

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -16,10 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 {{- with .Values.ingress.annotations }}
   annotations:

--- a/helm/oauth2-proxy/templates/poddisruptionbudget.yaml
+++ b/helm/oauth2-proxy/templates/poddisruptionbudget.yaml
@@ -3,15 +3,11 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "oauth2-proxy.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "oauth2-proxy.selectorLabels" . | nindent 6 }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/redis-secret.yaml
+++ b/helm/oauth2-proxy/templates/redis-secret.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}-redis-access
 type: Opaque
 data:

--- a/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
+++ b/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
@@ -5,10 +5,7 @@ kind: Secret
 type: Opaque
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
 {{- if .Values.authenticatedEmailsFile.annotations }}
   annotations:
 {{ toYaml .Values.authenticatedEmailsFile.annotations | indent 4 }}

--- a/helm/oauth2-proxy/templates/secret.yaml
+++ b/helm/oauth2-proxy/templates/secret.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 type: Opaque
 data:

--- a/helm/oauth2-proxy/templates/service.yaml
+++ b/helm/oauth2-proxy/templates/service.yaml
@@ -2,10 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 {{- if .Values.service.annotations }}
   annotations:

--- a/helm/oauth2-proxy/templates/serviceaccount.yaml
+++ b/helm/oauth2-proxy/templates/serviceaccount.yaml
@@ -7,9 +7,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 {{- end -}}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -45,6 +45,9 @@ image:
 extraArgs: {}
 extraEnv: []
 
+# Define labels to add to all k8s objects (to add labels only for pods, see podLabels)
+extraLabels: {}
+
 # To authorize individual email addresses
 # That is part of extraArgs but since this needs special treatment we need to do a separate section
 authenticatedEmailsFile:


### PR DESCRIPTION
Similar to PR #25

Add the possibility to specify extra labels in value file for all k8s objects.

New default labels are introduced:
- helm.sh/chart: {{ include "oauth2-proxy.chart" . }}
- app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
- app.kubernetes.io/managed-by: {{ .Release.Service }}
- app.kubernetes.io/name: {{ include "oauth2-proxy.name" . }}
- app.kubernetes.io/instance: {{ .Release.Name }}

Old labels are always present for backward compatibility:
heritage: {{ .Release.Service }}
chart: {{ template "oauth2-proxy.chart" . }}
app: {{ template "oauth2-proxy.name" . }}
release: {{ .Release.Name }}

matchLabels are done with new labels.
