### PR TITLE
Extending the configuration to allow custom email-address-list key

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.0.4
+version: 4.0.5
 apiVersion: v2
 appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -70,6 +70,7 @@ Parameter | Description | Default
 `authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
 `authenticatedEmailsFile.persistence` | Defines how the email addresses file will be projected, via a configmap or secret | `configmap`
 `authenticatedEmailsFile.template` | Name of the configmap or secret that is handled outside of that chart | `""`
+`authenticatedEmailsFile.restrictedUserAccessKey` | The key of the configmap or secret that holds the email addresses list | `""`
 `authenticatedEmailsFile.restricted_access` | [email addresses](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider#email-authentication) list config | `""`
 `authenticatedEmailsFile.annotations` | configmap or secret annotations | `nil`
 `config.clientID` | oauth client ID | `""`

--- a/helm/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
+++ b/helm/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
@@ -14,6 +14,6 @@ metadata:
 {{- end }}
   name: {{ template "oauth2-proxy.fullname" . }}-accesslist
 data:
-  restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | quote }}
+  {{ default "restricted_user_access" .Values.authenticatedEmailsFile.restrictedUserAccessKey }}: {{ .Values.authenticatedEmailsFile.restricted_access | quote }}
 {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -204,9 +204,9 @@ spec:
 
 {{- if and (.Values.authenticatedEmailsFile.enabled) (eq .Values.authenticatedEmailsFile.persistence "secret") }}
       - name: configaccesslist
-        secret: 
+        secret:
           items:
-          - key: restricted_user_access
+          - key: {{ default "restricted_user_access" .Values.authenticatedEmailsFile.restrictedUserAccessKey }}
 {{- if .Values.authenticatedEmailsFile.template }}
             path: {{ .Values.authenticatedEmailsFile.template }}
 {{- else }}
@@ -236,7 +236,7 @@ spec:
           name: {{ template "oauth2-proxy.fullname" . }}-accesslist
 {{- end }}
           items:
-          - key: restricted_user_access
+          - key: {{ default "restricted_user_access" .Values.authenticatedEmailsFile.restrictedUserAccessKey }}
 {{- if .Values.authenticatedEmailsFile.template }}
             path: {{ .Values.authenticatedEmailsFile.template }}
 {{- else }}

--- a/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
+++ b/helm/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
@@ -15,6 +15,6 @@ metadata:
 {{- end }}
   name: {{ template "oauth2-proxy.fullname" . }}-accesslist
 data:
-  restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | b64enc }}
+  {{ default "restricted_user_access" .Values.authenticatedEmailsFile.restrictedUserAccessKey }}: {{ .Values.authenticatedEmailsFile.restricted_access | b64enc }}
 {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -53,8 +53,12 @@ authenticatedEmailsFile:
   persistence: configmap
   # template is the name of the configmap what contains the email user list but has been configured without this chart.
   # It's a simpler way to maintain only one configmap (user list) instead changing it for each oauth2-proxy service.
-  # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access".
+  # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access" or to the
+  # provided value in restrictedUserAccessKey field.
   template: ""
+  # The configmap/secret key under which the list of email access is stored
+  # Defaults to "restricted_user_access" if not filled-in, but can be overridden to allow flexibility
+  restrictedUserAccessKey: ""
   # One email per line
   # example:
   # restricted_access: |-


### PR DESCRIPTION
Introduced a new field in the values, named `restrictedUserAccessKey` to allow for customization of the email-list key in the configmap or secret.
If no value is provided, it will default to the old "restricted_user_access" for backward compatibility.

Updated the documentation and bumped-up the chart minor version.

Fixes issue #44 