### PR TITLE
Expose metrics and add Prometheus ServiceMonitor

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.0.4
+version: 4.1.0
 apiVersion: v2
 appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -141,6 +141,14 @@ Parameter | Description | Default
 `sessionStorage.redis.sentinel.connectionUrls` | List of Redis sentinel connection URLs (e.g. redis://HOST[:PORT]) | `[]`
 `redis.enabled` | Enable the redis subchart deployment | `false`
 `checkDeprecation` | Enable deprecation checks | `true`
+`prometheus.enabled` | Enable Prometheus metrics endpoint | `true`
+`prometheus.metricsPort` | Serve Prometheus metrics on this port | `44180`
+`prometheus.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor monitoring | `false`
+`prometheus.servicemonitor.namespace` | Define namespace where to deploy the ServiceMonitor resource | `""`
+`prometheus.servicemonitor.prometheusInstance` | Prometheus Instance definition  | `default`
+`prometheus.servicemonitor.interval` | Prometheus scrape interval | `60s`
+`prometheus.servicemonitor.scrapeTimeout` | Prometheus scrape timeout | `30s`
+`prometheus.servicemonitor.labels` | Add custom labels to ServiceMonitor | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -142,14 +142,14 @@ Parameter | Description | Default
 `sessionStorage.redis.sentinel.connectionUrls` | List of Redis sentinel connection URLs (e.g. redis://HOST[:PORT]) | `[]`
 `redis.enabled` | Enable the redis subchart deployment | `false`
 `checkDeprecation` | Enable deprecation checks | `true`
-`prometheus.enabled` | Enable Prometheus metrics endpoint | `true`
-`prometheus.metricsPort` | Serve Prometheus metrics on this port | `44180`
-`prometheus.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor monitoring | `false`
-`prometheus.servicemonitor.namespace` | Define namespace where to deploy the ServiceMonitor resource | `""`
-`prometheus.servicemonitor.prometheusInstance` | Prometheus Instance definition  | `default`
-`prometheus.servicemonitor.interval` | Prometheus scrape interval | `60s`
-`prometheus.servicemonitor.scrapeTimeout` | Prometheus scrape timeout | `30s`
-`prometheus.servicemonitor.labels` | Add custom labels to ServiceMonitor | `{}`
+`metrics.enabled` | Enable Prometheus metrics endpoint | `true`
+`metrics.port` | Serve Prometheus metrics on this port | `44180`
+`metrics.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor | `false`
+`metrics.servicemonitor.namespace` | Define the namespace where to deploy the ServiceMonitor resource | `""`
+`metrics.servicemonitor.prometheusInstance` | Prometheus Instance definition  | `default`
+`metrics.servicemonitor.interval` | Prometheus scrape interval | `60s`
+`metrics.servicemonitor.scrapeTimeout` | Prometheus scrape timeout | `30s`
+`metrics.servicemonitor.labels` | Add custom labels to the ServiceMonitor resource| `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - --http-address=0.0.0.0:4180
+        {{- if .Values.prometheus.enabled }}
+          - --metrics-address=0.0.0.0:44180
+        {{- end }}
         {{- if .Values.config.cookieName }}
           - --cookie-name={{ .Values.config.cookieName }}
         {{- end }}
@@ -136,6 +139,11 @@ spec:
           - containerPort: 4180
             name: {{ .Values.httpScheme }}
             protocol: TCP
+{{- if .Values.prometheus.enabled }}
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+{{- end }}
 {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
@@ -204,7 +212,7 @@ spec:
 
 {{- if and (.Values.authenticatedEmailsFile.enabled) (eq .Values.authenticatedEmailsFile.persistence "secret") }}
       - name: configaccesslist
-        secret: 
+        secret:
           items:
           - key: restricted_user_access
 {{- if .Values.authenticatedEmailsFile.template }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - --http-address=0.0.0.0:4180
-        {{- if .Values.prometheus.enabled }}
+        {{- if .Values.metrics.enabled }}
           - --metrics-address=0.0.0.0:44180
         {{- end }}
         {{- if .Values.config.cookieName }}
@@ -139,7 +139,7 @@ spec:
           - containerPort: 4180
             name: {{ .Values.httpScheme }}
             protocol: TCP
-{{- if .Values.prometheus.enabled }}
+{{- if .Values.metrics.enabled }}
           - containerPort: 44180
             protocol: TCP
             name: metrics

--- a/helm/oauth2-proxy/templates/service.yaml
+++ b/helm/oauth2-proxy/templates/service.yaml
@@ -34,6 +34,12 @@ spec:
       targetPort: {{ .Values.httpScheme }}
       protocol: TCP
       name: {{ .Values.httpScheme }}
+    {{- if and .Values.prometheus.enabled .Values.prometheus.metricsPort }}
+    - port: {{ .Values.prometheus.metricsPort }}
+      protocol: TCP
+      targetPort: metrics
+      name: metrics
+    {{- end }}
   selector:
     app: {{ template "oauth2-proxy.name" . }}
     release: {{ .Release.Name }}

--- a/helm/oauth2-proxy/templates/service.yaml
+++ b/helm/oauth2-proxy/templates/service.yaml
@@ -34,8 +34,8 @@ spec:
       targetPort: {{ .Values.httpScheme }}
       protocol: TCP
       name: {{ .Values.httpScheme }}
-    {{- if and .Values.prometheus.enabled .Values.prometheus.metricsPort }}
-    - port: {{ .Values.prometheus.metricsPort }}
+    {{- if and .Values.metrics.enabled .Values.metrics.port }}
+    - port: {{ .Values.metrics.port }}
       protocol: TCP
       targetPort: metrics
       name: metrics

--- a/helm/oauth2-proxy/templates/servicemonitor.yaml
+++ b/helm/oauth2-proxy/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "oauth2-proxy.fullname" . }}
+{{- if .Values.prometheus.servicemonitor.namespace }}
+  namespace: {{ .Values.prometheus.servicemonitor.namespace }}
+{{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
+{{- if .Values.prometheus.servicemonitor.labels }}
+{{ toYaml .Values.prometheus.servicemonitor.labels | indent 4}}
+{{- end }}
+spec:
+  jobLabel: {{ template "oauth2-proxy.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "oauth2-proxy.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    path: "/metrics"
+    interval: {{ .Values.prometheus.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/helm/oauth2-proxy/templates/servicemonitor.yaml
+++ b/helm/oauth2-proxy/templates/servicemonitor.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.metrics.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "oauth2-proxy.fullname" . }}
-{{- if .Values.prometheus.servicemonitor.namespace }}
-  namespace: {{ .Values.prometheus.servicemonitor.namespace }}
+{{- if .Values.metrics.servicemonitor.namespace }}
+  namespace: {{ .Values.metrics.servicemonitor.namespace }}
 {{- else }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}
@@ -13,9 +13,9 @@ metadata:
     chart: {{ template "oauth2-proxy.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
-{{- if .Values.prometheus.servicemonitor.labels }}
-{{ toYaml .Values.prometheus.servicemonitor.labels | indent 4}}
+    prometheus: {{ .Values.metrics.servicemonitor.prometheusInstance }}
+{{- if .Values.metrics.servicemonitor.labels }}
+{{ toYaml .Values.metrics.servicemonitor.labels | indent 4}}
 {{- end }}
 spec:
   jobLabel: {{ template "oauth2-proxy.fullname" . }}
@@ -29,6 +29,6 @@ spec:
   endpoints:
   - port: metrics
     path: "/metrics"
-    interval: {{ .Values.prometheus.servicemonitor.interval }}
-    scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
+    interval: {{ .Values.metrics.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.metrics.servicemonitor.scrapeTimeout }}
 {{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -231,3 +231,22 @@ redis:
 
 # Enables apiVersion deprecation checks
 checkDeprecation: true
+
+prometheus:
+  # Enables Prometheus metrics endpoint
+  enabled: true
+  # Serve Prometheus metrics on this port
+  metricsPort: 44180
+  servicemonitor:
+    # Enable Prometheus Operator ServiceMonitor monitoring
+    enabled: false
+    # Define namespace where to deploy the ServiceMonitor resource
+    namespace: ""
+    # Prometheus Instance definition 
+    prometheusInstance: default
+    # Prometheus scrape interval
+    interval: 60s
+    # Prometheus scrape timeout
+    scrapeTimeout: 30s
+    # Add custom labels to ServiceMonitor
+    labels: {}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -233,7 +233,7 @@ redis:
 checkDeprecation: true
 
 prometheus:
-  # Enables Prometheus metrics endpoint
+  # Enable Prometheus metrics endpoint
   enabled: true
   # Serve Prometheus metrics on this port
   metricsPort: 44180

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -236,15 +236,15 @@ redis:
 # Enables apiVersion deprecation checks
 checkDeprecation: true
 
-prometheus:
+metrics:
   # Enable Prometheus metrics endpoint
   enabled: true
   # Serve Prometheus metrics on this port
-  metricsPort: 44180
+  port: 44180
   servicemonitor:
-    # Enable Prometheus Operator ServiceMonitor monitoring
+    # Enable Prometheus Operator ServiceMonitor
     enabled: false
-    # Define namespace where to deploy the ServiceMonitor resource
+    # Define the namespace where to deploy the ServiceMonitor resource
     namespace: ""
     # Prometheus Instance definition
     prometheusInstance: default
@@ -252,5 +252,5 @@ prometheus:
     interval: 60s
     # Prometheus scrape timeout
     scrapeTimeout: 30s
-    # Add custom labels to ServiceMonitor
+    # Add custom labels to the ServiceMonitor resource
     labels: {}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -242,7 +242,7 @@ prometheus:
     enabled: false
     # Define namespace where to deploy the ServiceMonitor resource
     namespace: ""
-    # Prometheus Instance definition 
+    # Prometheus Instance definition
     prometheusInstance: default
     # Prometheus scrape interval
     interval: 60s


### PR DESCRIPTION
OAuth2-Proxy now supports metrics, so I think it would make sense to expose those metrics and scrape them with a prometheus-operator ServiceMonitor.