### PR TITLE
Fix Google serviceAccountJson

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.4
+version: 5.0.5
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -197,7 +197,7 @@ spec:
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
       - name: google-secret
         secret:
-          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.secretName" $ }}{{ end }}
+          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }}{{ template "oauth2-proxy.fullname" $ }}-google{{ end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
The helm template for the `config.google.serviceAccountJson` was not working before.

How to use:
```yaml
config:
  google:
    adminEmail: "admin@my.com"
    serviceAccountJson: |
      {
        "type": "service_account",
        ...
      }
```