### PR TITLE
Update ingress.yaml: support empty list for .Values.ingress.hosts

### DIFF
--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -27,9 +27,31 @@ metadata:
 {{- end }}
 spec:
   rules:
+    {{- if .Values.ingress.hosts }}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host | quote }}
       http:
+        paths:
+{{- if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
+          {{- if $apiV1 }}
+          - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+          {{- else }}
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+          {{- end }}
+    {{- end -}}
+    {{- else }}
+    - http:
         paths:
 {{- if $extraPaths }}
 {{ toYaml $extraPaths | indent 10 }}
@@ -54,3 +76,4 @@ spec:
 {{ toYaml .Values.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}
+


### PR DESCRIPTION
For now, if the hosts field is not set, there will be an error while running `helm install`.

However, the host field is not forced to set in Kubernetes. No host field just means any host is accepted.

I update ingress.yaml so it won't throw error for empty hosts list then.