### PR TITLE
fixed TLS extraArgs in README

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.0.5
+version: 4.0.6
 apiVersion: v2
 appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -166,8 +166,8 @@ Use ```values.yaml``` like:
 ```yaml
 ...
 extraArgs:
-  tls-cert: /path/to/cert.pem
-  tls-key: /path/to/cert.key
+  tls-cert-file: /path/to/cert.pem
+  tls-key-file: /path/to/cert.key
 
 extraVolumes:
   - name: ssl-cert


### PR DESCRIPTION
The arguments `tls-cert` and `tls-key` were renamed in [commit 874c147e](https://github.com/oauth2-proxy/oauth2-proxy/commit/874c147e04210662f80c533fe09e22cea47498ad).