### PR TITLE
Allow specification of ingressClassName

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.1.1
+version: 4.2.0
 apiVersion: v2
 appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -96,6 +96,7 @@ Parameter | Description | Default
 `image.tag` | Image tag | `v7.1.3`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | Enable Ingress | `false`
+`ingress.className` | name referencing IngressClass | `nil`
 `ingress.path` | Ingress accepted path | `/`
 `ingress.pathType` | Ingress [path type](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) | `ImplementationSpecific`
 `ingress.extraPaths` | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -26,6 +26,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host | quote }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -92,6 +92,7 @@ serviceAccount:
 
 ingress:
   enabled: false
+  # className: nginx
   path: /
   # Only used if API capabilities (networking.k8s.io/v1) allow it
   pathType: ImplementationSpecific


### PR DESCRIPTION
The chart does not allow users to specify `ingressClassName`. In k8s 1.22, you either need to specify this name, or have an ingress class marked as default. This PR lets users specify the ingress class name in the resource through Helm.