### PR TITLE
Add custom config annotations

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.0
+version: 5.0.1
 apiVersion: v2
 appVersion: 7.1.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/configmap.yaml
+++ b/helm/oauth2-proxy/templates/configmap.yaml
@@ -3,6 +3,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+{{- if .Values.config.annotations }}
+  annotations:
+{{ toYaml .Values.config.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "oauth2-proxy.name" . }}
 {{- include "oauth2-proxy.labels" . | indent 4 }}

--- a/helm/oauth2-proxy/templates/secret.yaml
+++ b/helm/oauth2-proxy/templates/secret.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
+{{- if .Values.config.annotations }}
+  annotations:
+{{ toYaml .Values.config.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "oauth2-proxy.name" . }}
 {{- include "oauth2-proxy.labels" . | indent 4 }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -1,5 +1,7 @@
 # Oauth client configuration specifics
 config:
+  # Add config annotations
+  annotations: {}
   # OAuth client ID
   clientID: "XXXXXXX"
   # OAuth client secret


### PR DESCRIPTION
This allows users to add custom config annotations. This is extremely useful for users that deploy the chart via CD tools like Spinnaker that versions configs unless there is an annotation specified.

Maybe this should be part of #25


 