### PR TITLE
fix google service-account.json secret generation

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.2
+version: 5.0.3
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.3
+version: 5.0.4
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/google-secret.yaml
+++ b/helm/oauth2-proxy/templates/google-secret.yaml
@@ -8,5 +8,5 @@ metadata:
   name: {{ template "oauth2-proxy.fullname" . }}-google
 type: Opaque
 data:
-  service-account.json: {{ .Values.config.google.serviceAccountJson }}
+  service-account.json: {{ .Values.config.google.serviceAccountJson | b64enc | quote }}
 {{- end -}}

--- a/helm/oauth2-proxy/templates/google-secret.yaml
+++ b/helm/oauth2-proxy/templates/google-secret.yaml
@@ -8,5 +8,5 @@ metadata:
   name: {{ template "oauth2-proxy.fullname" . }}-google
 type: Opaque
 data:
-  service-account.json: {{ .serviceAccountJson }}
+  service-account.json: {{ .Values.config.google.serviceAccountJson }}
 {{- end -}}


### PR DESCRIPTION
I spend some time wrapping my head around this since it has been in the repository for quite some time, and I came to the conclusion that it's broken. I suppose not many people use membership verification ?

As a result you would get a `Secret` without value, which when applying with Terraform ends up in:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in Secret.data.service-account.json
```