### PR TITLE
[oauth2-proxy/PDB] Add Kubernetes 1.21+ support & fix broken selector labels

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.2
+version: 5.0.3
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/_capabilities.tpl
+++ b/helm/oauth2-proxy/templates/_capabilities.tpl
@@ -8,3 +8,16 @@ Returns the appropriate apiVersion for podDisruptionBudget object.
 {{- print "policy/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress object.
+*/}}
+{{- define "capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" ( .Values.kubeVersion | default .Capabilities.KubeVersion.Version ) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" ( .Values.kubeVersion | default .Capabilities.KubeVersion.Version ) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/oauth2-proxy/templates/_capabilities.tpl
+++ b/helm/oauth2-proxy/templates/_capabilities.tpl
@@ -2,9 +2,9 @@
 Returns the appropriate apiVersion for podDisruptionBudget object.
 */}}
 {{- define "capabilities.podDisruptionBudget.apiVersion" -}}
-{{- if semverCompare "<1.21-0" ( .Values.kubeVersion | default .Capabilities.KubeVersion.Version ) -}}
-{{- print "policy/v1beta1" -}}
-{{- else -}}
+{{- if semverCompare ">=1.21-0" ( .Values.kubeVersion | default .Capabilities.KubeVersion.Version ) -}}
 {{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
 {{- end -}}
 {{- end -}}

--- a/helm/oauth2-proxy/templates/_capabilities.tpl
+++ b/helm/oauth2-proxy/templates/_capabilities.tpl
@@ -1,0 +1,10 @@
+{{/*
+Returns the appropriate apiVersion for podDisruptionBudget object.
+*/}}
+{{- define "capabilities.podDisruptionBudget.apiVersion" -}}
+{{- if semverCompare "<1.21-0" ( .Values.kubeVersion | default .Capabilities.KubeVersion.Version ) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/oauth2-proxy/templates/_ingress.tpl
+++ b/helm/oauth2-proxy/templates/_ingress.tpl
@@ -39,7 +39,7 @@ service:
   port:
     {{- if typeIs "string" .servicePort }}
     name: {{ .servicePort }}
-    {{- else if typeIs "int" .servicePort }}
+    {{- else if or ( typeIs "int" .servicePort ) ( typeIs "float64" .servicePort ) }}
     number: {{ .servicePort }}
     {{- end }}
 {{- end -}}

--- a/helm/oauth2-proxy/templates/_ingress.tpl
+++ b/helm/oauth2-proxy/templates/_ingress.tpl
@@ -1,0 +1,46 @@
+{{/*
+Returns `true` if the API `ingressClassName` field is supported and `false` otherwise
+*/}}
+{{- define "ingress.supportsIngressClassName" -}}
+{{- if ( semverCompare "<1.18-0" ( .Values.kubeVersion | default .Capabilities.KubeVersion.Version ) ) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns `true` if the API `pathType` field is supported and `false` otherwise
+*/}}
+{{- define "ingress.supportsPathType" -}}
+{{- if ( semverCompare "<1.18-0" ( .Values.kubeVersion | default .Capabilities.KubeVersion.Version ) ) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the appropriate ingress `backend` fields depending on the Kubernetes API version.
+e.g.: `{{ include "common.ingress.backend" (dict "serviceName" "backendName" "servicePort" "backendPort" "context" $) }}`
+Where the dict must contain the following entries:
+- `serviceName` {String} - Name of an existing service backend
+- `servicePort` {String|Number} - Port name or port number of the service.
+- `context` {Dict} - (Parent) Context for the template evaluation required for the API version detection.
+*/}}
+{{- define "ingress.backend" -}}
+{{- $apiVersion := ( include "capabilities.ingress.apiVersion" .context ) -}}
+{{- if or ( eq $apiVersion "extensions/v1beta1" ) ( eq $apiVersion "networking.k8s.io/v1beta1" ) -}}
+serviceName: {{ .serviceName }}
+servicePort: {{ .servicePort }}
+{{- else -}}
+service:
+  name: {{ .serviceName }}
+  port:
+    {{- if typeIs "string" .servicePort }}
+    name: {{ .servicePort }}
+    {{- else if typeIs "int" .servicePort }}
+    number: {{ .servicePort }}
+    {{- end }}
+{{- end -}}
+{{- end -}}

--- a/helm/oauth2-proxy/templates/deprecation.yaml
+++ b/helm/oauth2-proxy/templates/deprecation.yaml
@@ -2,7 +2,7 @@
     {{- if .Values.service.port }}
         {{ fail "`service.port` does no longer exist. It has been renamed to `service.portNumber`" }}
     {{- end }}
-    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+    {{- if eq ( include "capabilities.ingress.apiVersion" . ) "networking.k8s.io/v1" -}}
         {{- range .Values.ingress.extraPaths }}
             {{- if or (.backend.serviceName) (.backend.servicePort) }}
                 {{ fail "Please update the format of your `ingress.extraPaths` to the new ingress apiVersion `networking.k8s.io/v1` format" }}

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -28,10 +28,10 @@ spec:
 {{ toYaml $extraPaths | indent 10 }}
 {{- end }}
           - path: {{ $ingressPath }}
-            {{- if eq "true" (include "ingress.supportsPathType" .) }}
+            {{- if eq "true" ( include "ingress.supportsPathType" $ ) }}
             pathType: {{ $ingressPathType }}
             {{- end }}
-            backend: {{- include "ingress.backend" (dict "serviceName" $serviceName "servicePort" $servicePort "context" $)  | nindent 14 }}
+            backend: {{- include "ingress.backend" ( dict "serviceName" $serviceName "servicePort" $servicePort "context" $ )  | nindent 14 }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -4,15 +4,7 @@
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
-{{- $apiV1 := false -}}
-{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0-0" .Capabilities.KubeVersion.Version) -}}
-apiVersion: networking.k8s.io/v1
-{{- $apiV1 = true -}}
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ include "capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   labels:
@@ -24,8 +16,8 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if and .Values.ingress.className ( eq "true" ( include "ingress.supportsIngressClassName" . ) ) }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
@@ -35,20 +27,11 @@ spec:
 {{- if $extraPaths }}
 {{ toYaml $extraPaths | indent 10 }}
 {{- end }}
-          {{- if $apiV1 }}
           - path: {{ $ingressPath }}
+            {{- if eq "true" (include "ingress.supportsPathType" .) }}
             pathType: {{ $ingressPathType }}
-            backend:
-              service:
-                name: {{ $serviceName }}
-                port:
-                  number: {{ $servicePort }}
-          {{- else }}
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-          {{- end }}
+            {{- end }}
+            backend: {{- include "ingress.backend" (dict "serviceName" $serviceName "servicePort" $servicePort "context" $)  | nindent 14 }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/helm/oauth2-proxy/templates/poddisruptionbudget.yaml
+++ b/helm/oauth2-proxy/templates/poddisruptionbudget.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "oauth2-proxy.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "oauth2-proxy.selectorLabels" . | indent 6 }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/poddisruptionbudget.yaml
+++ b/helm/oauth2-proxy/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "capabilities.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -1,3 +1,8 @@
+# Force the target Kubernetes version (it uses Helm `.Capabilities` if not set).
+# This is especially useful for `helm template` as capabilities are always empty
+# due to the fact that it doesn't query an actual cluster
+kubeVersion:
+
 # Oauth client configuration specifics
 config:
   # Add config annotations


### PR DESCRIPTION
Changeset:

feat: update PDB to support Kubernetes 1.21+ in a backward compatible fashion - Starting Kubernetes 1.21, the PDB feature went stable
fix: rework and fix broken PDB selector labels - It appears to have broken a long time ago and is related to 0ea4dc4a037a803191b03709896f08f689be6444 and cbd5275649b7aab0a1c01f71895e707460e5c607
chore: bump chart version (patch)