### PR TITLE
add support for alpha configuration.

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.0.1
+version: 6.1.0
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -80,7 +80,7 @@ For users who don't want downtime, you can perform these actions:
 
 ### To 6.0.0
 
-Version 6.0.0 bumps the version of the redis subchart from ~10.6.0 to ~16.4.0. You probably need to adjust your redis config. See [here](https://github.com/bitnami/charts/tree/master/bitnami/redis#upgrading) for detailed upgrade instructions. 
+Version 6.0.0 bumps the version of the redis subchart from ~10.6.0 to ~16.4.0. You probably need to adjust your redis config. See [here](https://github.com/bitnami/charts/tree/master/bitnami/redis#upgrading) for detailed upgrade instructions.
 
 ## Configuration
 
@@ -102,6 +102,12 @@ Parameter | Description | Default
 `config.configFile` | custom [oauth2_proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
 `config.existingConfig` | existing Kubernetes configmap to use for the configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/configmap.yaml) for the required values | `nil`
 `config.cookieName` | The name of the cookie that oauth2-proxy will create. | `""`
+`alphaConfig.enabled` | Flag to toggle any alpha config related logic | `false`
+`alphaConfig.annotations` | Configmap annotations | `{}`
+`alphaConfig.serverConfigData` | Arbitrary configuration data to append to the server section | `{}`
+`alphaConfig.metricsConfigData` | Arbitrary configuration data to append to the metrics section | `{}`
+`alphaConfig.configData` | Arbitrary configuration data to append | `{}`
+`alphaConfig.existingConfig` | existing Kubernetes configmap to use for the alpha configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/configmap-alpha.yaml) for the required values  | `nil`
 `customLabels` | Custom labels to add into metadata | `{}` |
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`
@@ -179,7 +185,7 @@ Parameter | Description | Default
 `metrics.servicemonitor.scrapeTimeout` | Prometheus scrape timeout | `30s`
 `metrics.servicemonitor.labels` | Add custom labels to the ServiceMonitor resource| `{}`
 `extraObjects` | Extra K8s manifests to deploy | `[]`
- 
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/helm/oauth2-proxy/templates/configmap-alpha.yaml
+++ b/helm/oauth2-proxy/templates/configmap-alpha.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.alphaConfig.enabled }}
+{{- if not .Values.alphaConfig.existingConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+{{- if .Values.alphaConfig.annotations }}
+  annotations: {{- toYaml .Values.alphaConfig.annotations | nindent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    {{- include "oauth2-proxy.labels" . | indent 4 }}
+  name: {{ template "oauth2-proxy.fullname" . }}-alpha
+data:
+  oauth2_proxy.yml: |
+    ---
+    server:
+      BindAddress: '0.0.0.0:4180'
+    {{- if .Values.alphaConfig.serverConfigData }}
+    {{- toYaml .Values.alphaConfig.serverConfigData | nindent 6 }}
+    {{- end }}
+    {{- if .Values.metrics.enabled }}
+    metricsServer:
+      BindAddress: '0.0.0.0:44180'
+    {{- if .Values.alphaConfig.metricsConfigData }}
+    {{- toYaml .Values.alphaConfig.metricsConfigData | nindent 6 }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.alphaConfig.configData }}
+    {{- toYaml .Values.alphaConfig.configData | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -54,9 +54,13 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+        {{- if .Values.alphaConfig.enabled }}
+          - --alpha-config=/etc/oauth2_proxy/oauth2_proxy.yml
+        {{- else }}
           - --http-address=0.0.0.0:4180
         {{- if .Values.metrics.enabled }}
           - --metrics-address=0.0.0.0:44180
+        {{- end }}
         {{- end }}
         {{- if .Values.config.cookieName }}
           - --cookie-name={{ .Values.config.cookieName }}
@@ -182,8 +186,14 @@ spec:
 {{- end }}
 {{- end }}
 {{- if or .Values.config.existingConfig .Values.config.configFile }}
-        - mountPath: /etc/oauth2_proxy
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
           name: configmain
+          subPath: oauth2_proxy.cfg
+{{- end }}
+{{- if .Values.alphaConfig.enabled }}
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.yml
+          name: configalpha
+          subPath: oauth2_proxy.yml
 {{- end }}
 {{- if .Values.authenticatedEmailsFile.enabled }}
         - mountPath: /etc/oauth2-proxy
@@ -240,6 +250,12 @@ spec:
           defaultMode: 420
           name: {{ if .Values.config.existingConfig }}{{ .Values.config.existingConfig }}{{ else }}{{ template "oauth2-proxy.fullname" . }}{{ end }}
         name: configmain
+{{- end }}
+{{- if .Values.alphaConfig.enabled }}
+      - configMap:
+          defaultMode: 420
+          name: {{ if .Values.alphaConfig.existingConfig }}{{ .Values.alphaConfig.existingConfig }}{{ else }}{{ template "oauth2-proxy.fullname" . }}-alpha{{ end }}
+        name: configalpha
 {{- end }}
 {{- if ne (len .Values.extraVolumes) 0 }}
 {{ toYaml .Values.extraVolumes | indent 6 }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -38,6 +38,19 @@ config:
   # Example:
   # existingConfig: config
 
+alphaConfig:
+  enabled: false
+  # Add config annotations
+  annotations: {}
+  # Arbitrary configuration data to append to the server section
+  serverConfigData: {}
+  # Arbitrary configuration data to append to the metrics section
+  metricsConfigData: {}
+  # Arbitrary configuration data to append
+  configData: {}
+  # Use an existing config map (see configmap-alpha.yaml for required fields)
+  existingConfig: ~
+
 image:
   repository: "quay.io/oauth2-proxy/oauth2-proxy"
   tag: "v7.2.0"


### PR DESCRIPTION
the alpha configuration provides access to experimental, as well
as advanced features not available with the "regular" config.

this change add support for either using an existing configmap
or creating one using the provided values.

obsoletes #36