### PR TITLE
Fix ServiceMonitor selector

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.5
+version: 5.0.6
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/servicemonitor.yaml
+++ b/helm/oauth2-proxy/templates/servicemonitor.yaml
@@ -19,8 +19,7 @@ spec:
   jobLabel: {{ template "oauth2-proxy.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "oauth2-proxy.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "oauth2-proxy.selectorLabels" . | indent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/oauth2-proxy/templates/servicemonitor.yaml
+++ b/helm/oauth2-proxy/templates/servicemonitor.yaml
@@ -9,11 +9,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}
   labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     prometheus: {{ .Values.metrics.servicemonitor.prometheusInstance }}
+    app: {{ template "oauth2-proxy.name" . }}
+{{- include "oauth2-proxy.labels" . | indent 4 }}
 {{- if .Values.metrics.servicemonitor.labels }}
 {{ toYaml .Values.metrics.servicemonitor.labels | indent 4}}
 {{- end }}


### PR DESCRIPTION
The ServiceMonitor selector uses hardcoded labels not matching the ones set by the Chart, this PR fixes that by using the appropriate helper for that.

Also updates the ServiceMonitor labels to use the common helper, so it's labels match the labels on the other resources.