### PR TITLE
feat: add deployment annotations field

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.3.0
+version: 5.4.0
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -129,6 +129,7 @@ Parameter | Description | Default
 `livenessProbe.initialDelaySeconds` | number of seconds | 0
 `livenessProbe.timeoutSeconds` | number of seconds | 1
 `nodeSelector` | node labels for pod assignment | `{}`
+`deploymentAnnotations` | annotations to add to the deployment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
 `podLabels` | additional labesl to add to each pod | `{}`
 `podDisruptionBudget.enabled`| Enabled creation of PodDisruptionBudget (only if replicaCount > 1) | true

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   labels:
     app: {{ template "oauth2-proxy.name" . }}
 {{- include "oauth2-proxy.labels" . | indent 4 }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 8 }} 
+  {{- end }}
   name: {{ template "oauth2-proxy.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -191,6 +191,7 @@ securityContext:
   # allowPrivilegeEscalation: false
   # runAsUser: 2000
 
+deploymentAnnotations: {}
 podAnnotations: {}
 podLabels: {}
 replicaCount: 1


### PR DESCRIPTION
Add a way to configure annotations on deployment. This allows the usage of https://github.com/stakater/Reloader in order to reload oauth2-proxy when the redis secret changes