### PR TITLE
Added ability to deploy extra K8s manifests

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.6
+version: 5.1.0
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -170,7 +170,8 @@ Parameter | Description | Default
 `metrics.servicemonitor.interval` | Prometheus scrape interval | `60s`
 `metrics.servicemonitor.scrapeTimeout` | Prometheus scrape timeout | `30s`
 `metrics.servicemonitor.labels` | Add custom labels to the ServiceMonitor resource| `{}`
-
+`extraObjects` | Extra K8s manifests to deploy | `[]`
+ 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/helm/oauth2-proxy/templates/extra-manifests.yaml
+++ b/helm/oauth2-proxy/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -265,3 +265,33 @@ metrics:
     scrapeTimeout: 30s
     # Add custom labels to the ServiceMonitor resource
     labels: {}
+
+# Extra K8s manifests to deploy
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: oauth2-proxy-secrets-store
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "oauth2-proxy"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "client_id"
+  #                 objectAlias: "client-id"
+  #               - path: "client_secret"
+  #                 objectAlias: "client-secret"
+  #               - path: "cookie_secret"
+  #                 objectAlias: "cookie-secret"
+  #     secretObjects:
+  #     - data:
+  #       - key: client-id
+  #         objectName: client-id
+  #         - key: client-secret
+  #           objectName: client-secret
+  #         - key: cookie-secret
+  #         objectName: cookie-secret
+  #       secretName: oauth2-proxy-secrets-store
+  #       type: Opaque


### PR DESCRIPTION
Signed-off-by: Nick Fisher <nxf5025@gmail.com>

By adding a secretProviderClass object to the helm chart we are able to mount secrets (such as our client secret) on the fly by leveraging the Secrets Store CSI Driver.

Documentation can be found here: https://github.com/kubernetes-sigs/secrets-store-csi-driver