### PR TITLE
fix redis password env ref when using existingSecret

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.0.0
+version: 6.0.1
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
 {{- include "oauth2-proxy.labels" . | indent 4 }}
   {{- if .Values.deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.deploymentAnnotations | indent 8 }} 
+{{ toYaml .Values.deploymentAnnotations | indent 8 }}
   {{- end }}
   name: {{ template "oauth2-proxy.fullname" . }}
 spec:
@@ -108,7 +108,7 @@ spec:
         {{- if eq (default "cookie" .Values.sessionStorage.type) "redis" }}
         - name: OAUTH2_PROXY_SESSION_STORE_TYPE
           value: "redis"
-        {{- if .Values.sessionStorage.redis.password }}
+        {{- if or .Values.sessionStorage.redis.password .Values.sessionStorage.redis.existingSecret }}
         - name: OAUTH2_PROXY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
There is a bug that leads to a situation where the environment variable OAUTH2_PROXY_REDIS_PASSWORD is not set on the deployment pod when using an existingSecret.

Signed-off-by: Nico Braun <rainbowstack@gmail.com>

Fixes #78 