### PR TITLE
compute the redis standalone url correctly

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.0.1
+version: 6.0.2
 apiVersion: v2
 appVersion: 7.2.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -78,11 +78,21 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-
+{{/*
+Compute the redis url if not set explicitly.
+*/}}
 {{- define "oauth2-proxy.redisStandaloneUrl" -}}
+{{- $masterPort := .Values.redis.master.service.ports.redis -}}
 {{- if .Values.sessionStorage.redis.standalone.connectionUrl -}}
 {{ .Values.sessionStorage.redis.standalone.connectionUrl }}
+{{- else if .Values.redis.fullnameOverride -}}
+{{- printf "redis://%s-master:%.0f" (.Values.redis.fullnameOverride | trunc 63 | trimSuffix "-") $masterPort -}}
 {{- else -}}
-{{- printf "redis://%s-redis-master:6379" (include "oauth2-proxy.fullname" .) -}}
+{{- $name := default "redis" .Values.redis.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "redis://%s-master:%.0f" (.Release.Name | trunc 63 | trimSuffix "-") $masterPort -}}
+{{- else -}}
+{{- printf "redis://%s-master:%.0f" (printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-") $masterPort -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -117,7 +117,7 @@ spec:
         {{- end }}
         {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}
         - name: OAUTH2_PROXY_REDIS_CONNECTION_URL
-          value: {{ include "oauth2-proxy.redisStandaloneUrl" . }}
+          value: {{ include "oauth2-proxy.redis.StandaloneUrl" . }}
         {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "cluster" }}
         - name: OAUTH2_PROXY_REDIS_USE_CLUSTER
           value: "true"


### PR DESCRIPTION
compute the redis url based on release name or name overrides instead of oauth2-proxy fullname helper

Signed-off-by: Nico Braun <rainbowstack@gmail.com>

Fixed: #82 