### PR TITLE
Support `--google-group` option

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.2.3
+version: 6.2.4
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.2.2
+version: 6.2.3
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -112,6 +112,7 @@ Parameter | Description | Default
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
+`config.google.groups` | restrict logins to members of these google groups | `[]`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `extraEnv` | key:value list of extra environment variables to give the binary | `[]`
 `extraVolumes` | list of extra volumes | `[]`

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -87,6 +87,11 @@ spec:
           - --google-admin-email={{ .adminEmail }}
           - --google-service-account-json=/google/service-account.json
         {{- end }}
+        {{- if .groups }}
+        {{- range $group := .groups }}
+          - --google-group={{ $group }}
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- if .Values.htpasswdFile.enabled }}
           - --htpasswd-file=/etc/oauth2_proxy/htpasswd/users.txt

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -26,6 +26,10 @@ config:
     # Alternatively, use an existing secret (see google-secret.yaml for required fields)
     # Example:
     # existingSecret: google-secret
+    # groups: []
+    # Example:
+    #  - group1@example.com
+    #  - group2@example.com
   # Default configuration, to be overridden
   configFile: |-
     email_domains = [ "*" ]


### PR DESCRIPTION
This option is required when `--google-admin-email` and `--google-service-account-json` options are used, the service is crushing without it.
This PR adds support for this option in the Helm chart by using the `config.google.groups` parameter.