### PR TITLE
Change references from SHA1 to BCrypt

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.2.2
+version: 6.2.3
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -120,7 +120,7 @@ Parameter | Description | Default
 `hostAlias.ip`  | `ip` address `hostAliases.hostname` should resolve to.
 `hostAlias.hostname`  | `hostname` associated to `hostAliases.ip`.
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`
-`htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options) | `{}`
+`htpasswdFile.entries` | list of [encrypted user:passwords](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options) | `{}`
 `htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file | `""`
 `httpScheme` | `http` or `https`. `name` used for port on the deployment. `httpGet` port `name` and `scheme` used for `liveness`- and `readinessProbes`. `name` and `targetPort` used for the service. | `http`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -222,7 +222,7 @@ podSecurityContext: {}
 # whether to use http or https
 httpScheme: http
 
-# Additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption.
+# Additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -B" for bcrypt encryption.
 # Alternatively supply an existing secret which contains the required information.
 htpasswdFile:
   enabled: false
@@ -231,7 +231,7 @@ htpasswdFile:
   # One row for each user
   # example:
   # entries:
-  #  - testuser:{SHA}EWhzdhgoYJWy0z2gyzhRYlN9DSiv
+  #  - testuser:$2y$05$gY6dgXqjuzFhwdhsiFe7seM9q9Tile4Y3E.CBpAZJffkeiLaC21Gy
 
 # Configure the session storage type, between cookie and redis
 sessionStorage:


### PR DESCRIPTION
This mirrors the main repository which already recommends BCrypt. See the command line documentation for  [htpasswd-file](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/#command-line-options).

SHA1 is cryptographically broken, and is generally neither recommended nor accepted by many applications these days. The [Wikipedia article](https://en.wikipedia.org/wiki/SHA-1) does a good job summarising its current state.