### PR TITLE
Bump oauth2-proxy image to latest release v7.2.1

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 6.2.0
+version: 6.2.1
 apiVersion: v2
-appVersion: 7.2.0
+appVersion: 7.2.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -125,7 +125,7 @@ Parameter | Description | Default
 `httpScheme` | `http` or `https`. `name` used for port on the deployment. `httpGet` port `name` and `scheme` used for `liveness`- and `readinessProbes`. `name` and `targetPort` used for the service. | `http`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `quay.io/oauth2-proxy/oauth2-proxy`
-`image.tag` | Image tag | `v7.2.0`
+`image.tag` | Image tag | `v7.2.1`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | Enable Ingress | `false`
 `ingress.className` | name referencing IngressClass | `nil`

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -53,7 +53,7 @@ alphaConfig:
 
 image:
   repository: "quay.io/oauth2-proxy/oauth2-proxy"
-  tag: "v7.2.0"
+  tag: "v7.2.1"
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Bug & security update which has no feature additions, per https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.2.1