### PR TITLE
Update version of Redis chart dependency

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - redis
 dependencies:
   - name: redis
-    version: ~16.4.0
+    version: ~17.1.7
     repository: https://charts.bitnami.com/bitnami
     alias: redis
     condition: redis.enabled


### PR DESCRIPTION
It seems to work for me with a "architecture: replication" setup and three Redis pods.  I have not tested cluster mode nor if the new major version has changes in actual API that might be considerd in the OAuth2-Proxy redis_store.go.