### PR TITLE
Make password key in Kubernetes secret configurable

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.4.0
+version: 6.5.0
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -107,7 +107,7 @@ Parameter | Description | Default
 `alphaConfig.serverConfigData` | Arbitrary configuration data to append to the server section | `{}`
 `alphaConfig.metricsConfigData` | Arbitrary configuration data to append to the metrics section | `{}`
 `alphaConfig.configData` | Arbitrary configuration data to append | `{}`
-`alphaConfig.existingConfig` | existing Kubernetes configmap to use for the alpha configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/configmap-alpha.yaml) for the required values  | `nil`
+`alphaConfig.existingConfig` | existing Kubernetes configmap to use for the alpha configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/configmap-alpha.yaml) for the required values | `nil`
 `customLabels` | Custom labels to add into metadata | `{}` |
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`
@@ -167,14 +167,17 @@ Parameter | Description | Default
 `securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
 `proxyVarsAsSecrets` | choose between environment values or secrets for setting up OAUTH2_PROXY variables. When set to false, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `true`
 `sessionStorage.type` | Session storage type which can be one of the following: cookie or redis | `cookie`
-`sessionStorage.redis.existingSecret` | existing Kubernetes secret to use for redis-password and redis-sentinel-password | `""`
+`sessionStorage.redis.existingSecret` | Name of the Kubernetes secret containing the redis & redis sentinel password values (see also `sessionStorage.redis.passwordKey`) | `""`
 `sessionStorage.redis.password` | Redis password. Applicable for all Redis configurations. Taken from redis subchart secret if not set. sessionStorage.redis.existingSecret takes precedence | `nil`
+`sessionStorage.redis.passwordKey` | Key of the Kubernetes secret data containing the redis password value | `redis-password`
 `sessionStorage.redis.clientType` | Allows the user to select which type of client will be used for redis instance. Possible options are: `sentinel`, `cluster` or `standalone` | `standalone`
-`sessionStorage.redis.standalone.connectionUrl` | URL of redis standalone server for redis session storage (e.g. redis://HOST[:PORT]). Automatically generated if not set. | `""`
-`sessionStorage.redis.cluster.connectionUrls` | List of Redis cluster connection URLs (e.g. redis://HOST[:PORT]) | `[]`
+`sessionStorage.redis.standalone.connectionUrl` | URL of redis standalone server for redis session storage (e.g. `redis://HOST[:PORT]`). Automatically generated if not set. | `""`
+`sessionStorage.redis.cluster.connectionUrls` | List of Redis cluster connection URLs (e.g. `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`) | `[]`
+`sessionStorage.redis.sentinel.existingSecret` | Name of the Kubernetes secret containing the redis sentinel password value (see also `sessionStorage.redis.sentinel.passwordKey`). Default: `sessionStorage.redis.existingSecret` | `""`
 `sessionStorage.redis.sentinel.password` | Redis sentinel password. Used only for sentinel connection; any redis node passwords need to use `sessionStorage.redis.password` | `nil`
+`sessionStorage.redis.sentinel.passwordKey` | Key of the Kubernetes secret data containing the redis sentinel password value | `redis-sentinel-password`
 `sessionStorage.redis.sentinel.masterName` | Redis sentinel master name | `nil`
-`sessionStorage.redis.sentinel.connectionUrls` | List of Redis sentinel connection URLs (e.g. redis://HOST[:PORT]) | `[]`
+`sessionStorage.redis.sentinel.connectionUrls` | List of Redis sentinel connection URLs (e.g. `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`) | `[]`
 `topologySpreadConstraints` | List of pod topology spread constraints | `[]`
 `redis.enabled` | Enable the redis subchart deployment | `false`
 `checkDeprecation` | Enable deprecation checks | `true`

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
               {{- else }}
               name: {{ include "oauth2-proxy.redis.fullname" . }}
               {{- end }}
-              key: redis-password
+              key: {{ .Values.sessionStorage.redis.passwordKey }}
         {{- end }}
         {{- if eq (default "" .Values.sessionStorage.redis.clientType) "standalone" }}
         - name: OAUTH2_PROXY_REDIS_CONNECTION_URL
@@ -146,12 +146,16 @@ spec:
           value: {{ .Values.sessionStorage.redis.sentinel.masterName }}
         - name: OAUTH2_PROXY_REDIS_SENTINEL_CONNECTION_URLS
           value: {{ .Values.sessionStorage.redis.sentinel.connectionUrls }}
-        {{- if .Values.sessionStorage.redis.sentinel.password }}
+        {{- if or .Values.sessionStorage.redis.sentinel.existingSecret .Values.sessionStorage.redis.existingSecret .Values.sessionStorage.redis.sentinel.password }}
         - name: OAUTH2_PROXY_REDIS_SENTINEL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ if .Values.sessionStorage.redis.existingSecret }} {{ .Values.sessionStorage.redis.existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" . }}-redis-access{{ end }}
-              key: redis-sentinel-password
+              {{- if or .Values.sessionStorage.redis.sentinel.existingSecret .Values.sessionStorage.redis.existingSecret }}
+              name: {{ .Values.sessionStorage.redis.sentinel.existingSecret | default .Values.sessionStorage.redis.existingSecret }}
+              {{- else }}
+              name: {{ template "oauth2-proxy.fullname" . }}-redis-access
+              {{- end }}
+              key: {{ .Values.sessionStorage.redis.sentinel.passwordKey }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/helm/oauth2-proxy/templates/redis-secret.yaml
+++ b/helm/oauth2-proxy/templates/redis-secret.yaml
@@ -12,11 +12,11 @@ metadata:
   name: {{ $fullName }}-redis-access
 type: Opaque
 data:
-  {{- with .redis.password }}
-  redis-password: {{ . | b64enc | quote }}
+  {{- if and .redis.password (not .redis.existingSecret) }}
+  {{ .redis.passwordKey }}: {{ .redis.password | b64enc | quote }}
   {{- end }}
-  {{- with .redis.sentinel.password }}
-  redis-sentinel-password: {{ . | b64enc | quote }}
+  {{- if and .redis.sentinel.password (not .redis.sentinel.existingSecret) (ne .redis.sentinel.passwordKey .redis.passwordKey) }}
+  {{ .redis.sentinel.passwordKey }}: {{ .redis.sentinel.password | b64enc | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -244,24 +244,33 @@ htpasswdFile:
 
 # Configure the session storage type, between cookie and redis
 sessionStorage:
-  # Can be one of the supported session storage cookie/redis
+  # Can be one of the supported session storage cookie|redis
   type: cookie
   redis:
-    # Secret name that holds the redis-password and redis-sentinel-password values
+    # Name of the Kubernetes secret containing the redis & redis sentinel password values (see also `sessionStorage.redis.passwordKey`)
     existingSecret: ""
+    # Redis password value. Applicable for all Redis configurations. Taken from redis subchart secret if not set. `sessionStorage.redis.existingSecret` takes precedence
     password: ""
-    # Can be one of sentinel/cluster/standalone
+    # Key of the Kubernetes secret data containing the redis password value
+    passwordKey: "redis-password"
+    # Can be one of standalone|cluster|sentinel
     clientType: "standalone"
     standalone:
-      # If empty and sessionStorage type is redis, will automatically be generated.
+      # URL of redis standalone server for redis session storage (e.g. `redis://HOST[:PORT]`). Automatically generated if not set
       connectionUrl: ""
     cluster:
-      # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]
+      # List of Redis cluster connection URLs (e.g. `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`)
       connectionUrls: []
     sentinel:
+      # Name of the Kubernetes secret containing the redis sentinel password value (see also `sessionStorage.redis.sentinel.passwordKey`). Default: `sessionStorage.redis.existingSecret`
+      existingSecret: ""
+      # Redis sentinel password. Used only for sentinel connection; any redis node passwords need to use `sessionStorage.redis.password`
       password: ""
+      # Key of the Kubernetes secret data containing the redis sentinel password value
+      passwordKey: "redis-sentinel-password"
+      # Redis sentinel master name
       masterName: ""
-      # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]
+      # List of Redis sentinel connection URLs (e.g. `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`)
       connectionUrls: []
 
 # Enables and configure the automatic deployment of the redis subchart


### PR DESCRIPTION
Fixes #115 by adding an option to adjust the key of the secret data object containing the password for redis & its sentinel.

New configuration options:
- `sessionStorage.redis.passwordKey` (previously hard-coded as `redis-password`)
- `sessionStorage.redis.sentinel.passwordKey` (previously hard-coded as `redis-sentinel-password`)

I also added a new option `sessionStorage.redis.sentinel.existingSecret` to configure the sentinel indepent of the redis. This is not necessary to fix the issue above and can be removed. I just thought it might be useful for anybody in the future.

I also synchronized some documentation between README.md and values.yaml. Not sure if maintaining docs in two places is a good idea though. As a regular user of artifacthub I only have had a look at the values.yaml before creating this PR - just saying :)