### PR TITLE
Set https port to 4443

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.3.0
+version: 6.3.1
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
           - --alpha-config=/etc/oauth2_proxy/oauth2_proxy.yml
         {{- else }}
           - --http-address=0.0.0.0:4180
+          - --https-address=0.0.0.0:4443
         {{- if .Values.metrics.enabled }}
           - --metrics-address=0.0.0.0:44180
         {{- end }}
@@ -159,7 +160,11 @@ spec:
 {{ tpl (toYaml .Values.extraEnv) . | indent 8 }}
         {{- end }}
         ports:
+          {{- if eq .Values.httpScheme "http" }}
           - containerPort: 4180
+          {{- else }}
+          - containerPort: 4443
+          {{- end }}
             name: {{ .Values.httpScheme }}
             protocol: TCP
 {{- if .Values.metrics.enabled }}


### PR DESCRIPTION
Default port for https was 443 ([ref](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/docs/configuration/overview.md?plain=1#L126)) but it is not allowed for binding by a non-root user.
This is what occurs in the default image of this helm chart, so this is a fix for an error appeared when the value "httpScheme" is set to "https".