### PR TITLE
Correct label in NOTES.txt

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.5.0
+version: 6.5.1
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/NOTES.txt
+++ b/helm/oauth2-proxy/templates/NOTES.txt
@@ -1,3 +1,3 @@
 To verify that oauth2-proxy has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "oauth2-proxy.fullname" . }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "oauth2-proxy.name" . }}"


### PR DESCRIPTION
The `app` label on the pods is set based on the `name` template, not the `fullname` template. In cases where they are different (for example, if the release name is not `oauth2-proxy`, and neither `nameOverride` nor `fullnameOverride` are set), the instructions in the rendered notes would be incorrect.