### PR TITLE
Checksum for alphaConfig

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.5.0
+version: 6.5.1
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.5.1
+version: 6.5.2
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.alphaConfig.enabled }}
+        checksum/alpha-config: {{ include (print $.Template.BasePath "/configmap-alpha.yaml") . | sha256sum }}
+        {{- end }}
         checksum/config-emails: {{ include (print $.Template.BasePath "/configmap-authenticated-emails-file.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         checksum/google-secret: {{ include (print $.Template.BasePath "/google-secret.yaml") . | sha256sum }}


### PR DESCRIPTION
This patch adds a checksum to the deployment to trigger a restart of the pods, if the config-alpha changes. Pretty similar to the remaining checksums.

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>