### PR TITLE
Add appProtocol to Service Ports

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.5.0
+version: 6.5.1
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.5.1
+version: 6.5.2
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.5.2
+version: 6.6.2
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -155,6 +155,7 @@ Parameter | Description | Default
 `replicaCount` | desired number of pods | `1`
 `resources` | pod resource requests & limits | `{}`
 `service.portNumber` | port number for the service | `80`
+`service.appProtocol` | application protocol on the port of the service | `http`
 `service.type` | type of service | `ClusterIP`
 `service.clusterIP` | cluster ip address | `nil`
 `service.loadBalancerIP` | ip of load balancer | `nil`
@@ -185,6 +186,7 @@ Parameter | Description | Default
 `metrics.enabled` | Enable Prometheus metrics endpoint | `true`
 `metrics.port` | Serve Prometheus metrics on this port | `44180`
 `metrics.nodePort` | External port for the metrics when service.type is `NodePort` | `nil`
+`metrics.service.appProtocol` | application protocol of the metrics port in the service | `http`
 `metrics.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor | `false`
 `metrics.servicemonitor.namespace` | Define the namespace where to deploy the ServiceMonitor resource | `""`
 `metrics.servicemonitor.prometheusInstance` | Prometheus Instance definition  | `default`

--- a/helm/oauth2-proxy/templates/service.yaml
+++ b/helm/oauth2-proxy/templates/service.yaml
@@ -34,10 +34,16 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       protocol: TCP
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
       name: {{ .Values.httpScheme }}
     {{- if and .Values.metrics.enabled .Values.metrics.port }}
     - port: {{ .Values.metrics.port }}
       protocol: TCP
+      {{- with .Values.metrics.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
       targetPort: metrics
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.metrics.nodePort))) }}
       nodePort: {{ .Values.metrics.nodePort }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -107,6 +107,8 @@ service:
   # when service.type is NodePort ...
   # nodePort: 80
   portNumber: 80
+  # Protocol set on the service
+  appProtocol: http
   annotations: {}
   # foo.io/bar: "true"
 
@@ -296,6 +298,9 @@ metrics:
   port: 44180
   # when service.type is NodePort ...
   # nodePort: 44180
+  # Protocol set on the service for the metrics port
+  service:
+    appProtocol: http
   servicemonitor:
     # Enable Prometheus Operator ServiceMonitor
     enabled: false


### PR DESCRIPTION
This patch adds the appProtocol fields to the service ports. Some tools, like istio's service mesh are using those to specify how to handle the traffic.

Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>