### PR TITLE
extraArgs as a list

### DIFF
--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -113,7 +113,7 @@ Parameter | Description | Default
 `config.google.serviceAccountJson` | google service account json contents | `""`
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
 `config.google.groups` | restrict logins to members of these google groups | `[]`
-`extraArgs` | key:value list of extra arguments to give the binary | `{}`
+`extraArgs` | Extra arguments to give the binary. Either as a map with key:value pairs or as a list type, which allows to configure the same flag multiple times. (e.g. `["--allowed-role=CLIENT_ID:CLIENT_ROLE_NAME_A", "--allowed-role=CLIENT_ID:CLIENT_ROLE_NAME_B"]`). | `{}` or `[]`
 `extraEnv` | key:value list of extra environment variables to give the binary | `[]`
 `extraVolumes` | list of extra volumes | `[]`
 `extraVolumeMounts` | list of extra volumeMounts | `[]`

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -67,11 +67,18 @@ spec:
         {{- if .Values.config.cookieName }}
           - --cookie-name={{ .Values.config.cookieName }}
         {{- end }}
-        {{- range $key, $value := .Values.extraArgs }}
+        {{- if kindIs "map" .Values.extraArgs }}
+          {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
           - --{{ $key }}={{ $value }}
           {{- else }}
           - --{{ $key }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- if kindIs "slice" .Values.extraArgs }}
+          {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
         {{- if or .Values.config.existingConfig .Values.config.configFile }}


### PR DESCRIPTION
Hi, 

May I suggest this implement in order to give the ability to supply multiple extraArgs.
Tested locally, doesn't seem to break compatibility.

e.g. user can chose between: 
```yaml
extraArgs:
  pass-authorization-header: "true"
  request-logging: "true"
  allowed-role: client_id:client_role
```
OR:
```yaml
extraArgs:
  - --pass-authorization-header="true"
  - --request-logging="true"
  - --allowed-role=client_id:client_role_A
  - --allowed-role=client_id:client_role_B
  ```
  
  Solves #101 
  
  Any thoughts ?