### PR TITLE
fix(deps): upgrade redis subchart to 16.13.2.

### DIFF
--- a/helm/oauth2-proxy/Chart.lock
+++ b/helm/oauth2-proxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.4.0
-digest: sha256:a6a2b7e848cc6c48dc175d8e6aa23651385f8d317f33bbb4fea97db822c3d445
-generated: "2022-02-10T12:48:38.7766769+01:00"
+  version: 16.13.2
+digest: sha256:6fc589816ba4670d6f38cc724cba9b728d10a041a2cef4425a62c22f9a1aa5f6
+generated: "2022-12-20T18:22:05.758522+01:00"

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.5.1
+version: 6.5.2
 apiVersion: v2
 appVersion: 7.3.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -14,7 +14,7 @@ keywords:
   - redis
 dependencies:
   - name: redis
-    version: ~16.4.0
+    version: ~16.13.2
     repository: https://charts.bitnami.com/bitnami
     alias: redis
     condition: redis.enabled


### PR DESCRIPTION
Note that older redis versions are being stripped from bitnami repo: https://github.com/bitnami/charts/issues/8433 and prevent release (actually: preventing helm dep up)