### PR TITLE
Added support for using Workload Identity to the Helm chart

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.7.4
+version: 6.8.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.7.3
+version: 6.7.4
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -111,6 +111,7 @@ Parameter | Description | Default
 `customLabels` | Custom labels to add into metadata | `{}` |
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.useApplicationDefaultCredentials` | use the application-default credentials (i.e. Workload Identity on GKE) instead of providing a service account json | `false`
+`config.google.targetPrincipal` | service account to use/impersonate | `""`
 `config.google.serviceAccountJson` | google service account json contents | `""`
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
 `config.google.groups` | restrict logins to members of these google groups | `[]`

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -110,6 +110,7 @@ Parameter | Description | Default
 `alphaConfig.existingConfig` | existing Kubernetes configmap to use for the alpha configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/configmap-alpha.yaml) for the required values | `nil`
 `customLabels` | Custom labels to add into metadata | `{}` |
 `config.google.adminEmail` | user impersonated by the google service account | `""`
+`config.google.useApplicationDefaultCredentials` | use the application-default credentials (i.e. Workload Identity on GKE) instead of providing a service account json | `false`
 `config.google.serviceAccountJson` | google service account json contents | `""`
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
 `config.google.groups` | restrict logins to members of these google groups | `[]`

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -102,6 +102,9 @@ spec:
         {{- else }}
           - --google-service-account-json=/google/service-account.json
         {{- end }}
+        {{- if .targetPrincipal }}
+          - --google-target-principal={{ .targetPrincipal }}
+        {{- end }}
         {{- end }}
         {{- if .groups }}
         {{- range $group := .groups }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -95,9 +95,13 @@ spec:
         {{- end }}
         {{- end }}
         {{- with .Values.config.google }}
-        {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
+        {{- if and .adminEmail (or .serviceAccountJson .existingSecret .useApplicationDefaultCredentials) }}
           - --google-admin-email={{ .adminEmail }}
+        {{- if .useApplicationDefaultCredentials }}
+          - --google-use-application-default-credentials=true
+        {{- else }}
           - --google-service-account-json=/google/service-account.json
+        {{- end }}
         {{- end }}
         {{- if .groups }}
         {{- range $group := .groups }}

--- a/helm/oauth2-proxy/templates/google-secret.yaml
+++ b/helm/oauth2-proxy/templates/google-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.google (not .Values.config.google.existingSecret) }}
+{{- if and .Values.config.google (and (not .Values.config.google.existingSecret) (not .Values.config.google.useApplicationDefaultCredentials)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -22,6 +22,7 @@ config:
   cookieName: ""
   google: {}
     # adminEmail: xxxx
+    # useApplicationDefaultCredentials: true
     # serviceAccountJson: xxxx
     # Alternatively, use an existing secret (see google-secret.yaml for required fields)
     # Example:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -23,6 +23,7 @@ config:
   google: {}
     # adminEmail: xxxx
     # useApplicationDefaultCredentials: true
+    # targetPrincipal: xxxx
     # serviceAccountJson: xxxx
     # Alternatively, use an existing secret (see google-secret.yaml for required fields)
     # Example:


### PR DESCRIPTION
Requires https://github.com/oauth2-proxy/oauth2-proxy/pull/1967 to be merged first