### PR TITLE
Pass oauth2-proxy config through helm templating

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.8.0
+version: 6.9.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/ci/tpl-values.yaml
+++ b/helm/oauth2-proxy/ci/tpl-values.yaml
@@ -1,0 +1,21 @@
+extraEnv:
+  - name: TEST_ENV_VAR_2
+    value: '{{ $.Release.Name }}'
+ingress:
+  enabled: true
+  hosts:
+    - "{{ $.Release.Name }}.local"
+  tls:
+    - hosts:
+        - "{{ $.Release.Name }}.local"
+oauth2-proxy:
+  checkDeprecation: false
+  config:
+    clientSecret: '{{ $.Release.Name }}'
+    configFile: |
+      oidc_issuer_url = "https://{{ $.Release.Name }}/dex"
+
+pass_authorization_header: "true"
+
+extraArgs:
+  pass-authorization-header: "{{ $.Values.pass_authorization_header }}"

--- a/helm/oauth2-proxy/templates/configmap.yaml
+++ b/helm/oauth2-proxy/templates/configmap.yaml
@@ -12,6 +12,6 @@ metadata:
 {{- include "oauth2-proxy.labels" . | indent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}
 data:
-  oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
+  oauth2_proxy.cfg: {{ tpl .Values.config.configFile $ | quote }}
 {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         {{- if kindIs "map" .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
-          - --{{ $key }}={{ $value }}
+          - --{{ $key }}={{ tpl $value $ }}
           {{- else }}
           - --{{ $key }}
           {{- end }}

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
   {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host | quote }}
+    - host: {{ tpl $host $ | quote }}
       http:
         paths:
 {{- if $extraPaths }}
@@ -35,6 +35,6 @@ spec:
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+{{ tpl (toYaml .Values.ingress.tls) $ | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/helm/oauth2-proxy/templates/secret.yaml
+++ b/helm/oauth2-proxy/templates/secret.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ template "oauth2-proxy.fullname" . }}
 type: Opaque
 data:
-  cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
-  client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
-  client-id: {{ .Values.config.clientID | b64enc | quote }}
+  cookie-secret: {{ tpl .Values.config.cookieSecret $ | b64enc | quote }}
+  client-secret: {{ tpl .Values.config.clientSecret $ | b64enc | quote }}
+  client-id: {{ tpl .Values.config.clientID $ | b64enc | quote }}
 {{- end -}}


### PR DESCRIPTION
This PR enabled passing configuration through the helm templating engine again.

Use cases:
We have a umbrella helm charts which bundles all helm charts together in one release. Using the pattern, we are able to establish a single configuration plane for multiple components.

In this case, we would like to share some configuration between oauth2-proxy and dex idp. For example dexidp and oauth-proxy shares the same issuer config, client id, client secret.

oauth2-proxy also shares some configuration with grafana, e.g. ingress hostname.

The [grafana](https://github.com/grafana/helm-charts/blob/2987944b43d77f9081fe7d7be40179e281df3917/charts/grafana/templates/ingress.yaml#L37) and [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/edb39f574b95038229ca1b09468cc01b37214637/charts/kube-prometheus-stack/templates/alertmanager/secret.yaml#L19) already allows use similar configurations. 

Giving an example for values files

```yaml
oauth2-proxy:
  checkDeprecation: false
  config:
    clientSecret: '{{ $.Values.global.features.auth.secrets.proxyClientSecret }}'
    configFile: |
      oidc_issuer_url = "https://{{ $.Values.global.features.auth.hostname }}/dex"
  ingress:
    enabled: ture
    annotations:
      cert-manager.io/cluster-issuer: letsencrypt
    className: nginx
    path: /oauth2/
    pathType: Prefix
    hosts:
      - '{{ $.Values.global.features.grafana.hostname }}'
    tls:
      - secretName: tls-secret-grafana
        hosts:
          - '{{ $.Values.global.features.grafana.hostname }}'
```