### PR TITLE
ensure values are string before passing to helm templating engine

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.9.0
+version: 6.9.1
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         {{- if kindIs "map" .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
-          - --{{ $key }}={{ tpl $value $ }}
+          - --{{ $key }}={{ tpl ($value | toString) $ }}
           {{- else }}
           - --{{ $key }}
           {{- end }}


### PR DESCRIPTION
Introduced in #132 
Fixes #133

By using `--set extraArgs.set-authorization-header="true"`, helm will convert the value to a boolean value, since the value is boolean parsable.

For such scenarios, helm has additional flag `--set-string` to disable Interpretation of values.

The tpl function in helm always expecting strings. The PR ensure that the value is always a string before passing it into the tpl function. 