### PR TITLE
Add ability to set custom tag without rendering it with  'v' prefix

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.9.0
+version: 6.10.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -106,5 +106,5 @@ Compute the redis url if not set explicitly.
 Returns the version
 */}}
 {{- define "oauth2-proxy.version" -}}
-{{ trimPrefix "v" (lower (.Values.image.tag | default (printf "v%s" .Chart.AppVersion))) }}
+{{ lower (.Values.image.tag | default (printf "v%s" .Chart.AppVersion)) }}
 {{- end -}}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:v{{ include "oauth2-proxy.version" . }}"
+        image: "{{ .Values.image.repository }}:{{ include "oauth2-proxy.version" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         {{- if .Values.alphaConfig.enabled }}


### PR DESCRIPTION
Hi!

When i tried using this chart with custom image & tag provided, i've faced an error, because we build images with tags in the form of X.X.X, but chart doesn't provide any ability to use it without `v` prefix. So this small change addresses the issue and resolves it

BR