### PR TITLE
Add extraContainers: [] configuration option

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.9.2
+version: 6.10.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.9.1
+version: 6.9.2
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -120,6 +120,7 @@ Parameter | Description | Default
 `extraEnv` | key:value list of extra environment variables to give the binary | `[]`
 `extraVolumes` | list of extra volumes | `[]`
 `extraVolumeMounts` | list of extra volumeMounts | `[]`
+`extraContainers` | List of extra containers to be added to the pod | `[]`
 `hostAlias.enabled`  | provide extra ip:hostname alias for network name resolution.
 `hostAlias.ip`  | `ip` address `hostAliases.hostname` should resolve to.
 `hostAlias.hostname`  | `hostname` associated to `hostAliases.ip`.

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -117,10 +117,10 @@ Parameter | Description | Default
 `config.google.groups` | restrict logins to members of these google groups | `[]`
 `containerPort` | used to customise port on the deployment | `""`
 `extraArgs` | Extra arguments to give the binary. Either as a map with key:value pairs or as a list type, which allows to configure the same flag multiple times. (e.g. `["--allowed-role=CLIENT_ID:CLIENT_ROLE_NAME_A", "--allowed-role=CLIENT_ID:CLIENT_ROLE_NAME_B"]`). | `{}` or `[]`
+`extraContainers` | List of extra containers to be added to the pod | `[]`
 `extraEnv` | key:value list of extra environment variables to give the binary | `[]`
 `extraVolumes` | list of extra volumes | `[]`
 `extraVolumeMounts` | list of extra volumeMounts | `[]`
-`extraContainers` | List of extra containers to be added to the pod | `[]`
 `hostAlias.enabled`  | provide extra ip:hostname alias for network name resolution.
 `hostAlias.ip`  | `ip` address `hostAliases.hostname` should resolve to.
 `hostAlias.hostname`  | `hostname` associated to `hostAliases.ip`.

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -254,6 +254,9 @@ spec:
         securityContext:
           {{- toYaml $securityContext | nindent 10 }}
 {{- end }}
+{{- if .Values.extraContainers }}
+  {{- toYaml .Values.extraContainers | nindent 6 }}
+{{- end }}
       volumes:
 {{- with .Values.config.google }}
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -175,6 +175,11 @@ extraVolumeMounts: []
   # - mountPath: /etc/ssl/certs/
   #   name: ca-bundle-cert
 
+# Additional containers to be added to the pod.
+extraContainers: []
+  #  - name: my-sidecar
+  #    image: nginx:latest
+
 priorityClassName: ""
 
 # Host aliases, useful when working "on premise" where (public) DNS resolver does not know about my hosts.


### PR DESCRIPTION
Add `extraContainers: []` configuration option to the chart, so that it's possible to insert a sidecar container. Could for example be useful to achieve setups like [this](https://www.callumpember.com/Kubernetes-A-Single-OAuth2-Proxy-For-Multiple-Ingresses/).