### PR TITLE
fix: allow literal 0 values in deployment.yaml extraArgs templating

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.10.1
+version: 6.13.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         {{- end }}
         {{- if kindIs "map" .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
-          {{- if $value }}
+          {{- if not (kindIs "invalid" $value) }}
           - --{{ $key }}={{ tpl ($value | toString) $ }}
           {{- else }}
           - --{{ $key }}


### PR DESCRIPTION
Some of the available arguments to be passed to `extraArgs` allow for literal 0 values, such as the `--cookie-refresh` setting.

However, setting it to `0` causes the `{{ if $value }}` check to logically return as falsy, thanks to gotpl.

This replacement check instead looks for invalid value kinds (i.e. nil/null, explicitly empty)