### PR TITLE
Way to disable appProtocol

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.13.3
+version: 6.14.1
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.10.1
+version: 6.12.2
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/service.yaml
+++ b/helm/oauth2-proxy/templates/service.yaml
@@ -34,15 +34,19 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       protocol: TCP
+      {{- if .Values.service.appProtocol }}
       {{- with .Values.service.appProtocol }}
       appProtocol: {{ . }}
+      {{- end }}
       {{- end }}
       name: {{ .Values.httpScheme }}
     {{- if and .Values.metrics.enabled .Values.metrics.port }}
     - port: {{ .Values.metrics.port }}
       protocol: TCP
+      {{- if .Values.metrics.service.appProtocol }}
       {{- with .Values.metrics.service.appProtocol }}
       appProtocol: {{ . }}
+      {{- end }}
       {{- end }}
       targetPort: metrics
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.metrics.nodePort))) }}


### PR DESCRIPTION
[K8s older than 1.20](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol), can't understand appProtocol in service description, so let's add way to disable appProtocol.

