### PR TITLE
Add proxyVarsFromSecret: "" option

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.15.1
+version: 6.17.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,9 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: optional init container to wait for redis subchart's master pod to be ready
+      description: Add proxyVarsFromSecret: "" option
       links:
-        - name: Github Issue
-          url: https://github.com/oauth2-proxy/manifests/issues/91
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/92
+          url: https://github.com/oauth2-proxy/manifests/pull/141

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.23.1
+version: 6.24.0
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.13.0
+version: 6.14.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 6.17.0
+version: 6.18.0
 apiVersion: v2
-appVersion: 7.4.0
+appVersion: 7.5.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.10.2
+version: 6.11.1
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.14.0
+version: 6.15.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.3.0
+version: 7.4.0
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.15.0
+version: 6.15.1
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.10.1
+version: 6.10.2
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -160,8 +160,8 @@ spec:
               name:  {{ template "oauth2-proxy.secretName" . }}
               key: cookie-secret
         {{- end }}
-        envFrom:
         {{- with .Values.proxyVarsFromSecret }}  
+        envFrom:
         - secretRef:
             name: {{  . }}
         {{- end }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -136,6 +136,11 @@ spec:
               name:  {{ template "oauth2-proxy.secretName" . }}
               key: cookie-secret
         {{- end }}
+        envFrom:
+        {{- with .Values.proxyVarsFromSecret }}  
+        - secretRef:
+            name: {{  . }}
+        {{- end }}
         {{- if eq (default "cookie" .Values.sessionStorage.type) "redis" }}
         - name: OAUTH2_PROXY_SESSION_STORE_TYPE
           value: "redis"

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -207,6 +207,9 @@ nodeSelector: {}
 # Whether to use secrets instead of environment values for setting up OAUTH2_PROXY variables
 proxyVarsAsSecrets: true
 
+# Allows to import environment values for OAUTH2_PROXY directly from a secret
+proxyVarsFromSecret: ""
+
 # Configure Kubernetes liveness and readiness probes.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 # Disable both when deploying with Istio 1.0 mTLS. https://istio.io/help/faq/security/#k8s-health-checks


### PR DESCRIPTION
added option to load OAUTH2_PROXY variables directly from a secret

**Reasoning**
ExternalSecrets with GitLab provider makes this chart really hard to use, since you cannot name a GitLab CI/CD variable using "-" such as `cookie-secret`.