### PR TITLE
Support ingress extra labels

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.11.0
+version: 6.12.0
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -137,6 +137,7 @@ Parameter | Description | Default
 `ingress.path` | Ingress accepted path | `/`
 `ingress.pathType` | Ingress [path type](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) | `ImplementationSpecific`
 `ingress.extraPaths` | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`
+`ingress.labels` | Ingress extra labels | `{}`
 `ingress.annotations` | Ingress annotations | `nil`
 `ingress.hosts` | Ingress accepted hostnames | `nil`
 `ingress.tls` | Ingress TLS configuration | `nil`

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -9,7 +9,10 @@ kind: Ingress
 metadata:
   labels:
     app: {{ template "oauth2-proxy.name" . }}
-{{- include "oauth2-proxy.labels" . | indent 4 }}
+    {{- include "oauth2-proxy.labels" . | indent 4 }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
   name: {{ template "oauth2-proxy.fullname" . }}
   namespace: {{ template "oauth2-proxy.namespace" $ }}
 {{- with .Values.ingress.annotations }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -153,6 +153,7 @@ ingress:
   #       name: ssl-redirect
   #       port:
   #         name: use-annotation
+  labels: {}
   # annotations:
   #   kubernetes.io/ingress.class: nginx
   #   kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
In my setup I use several ingress classes with `external-dns`. `external-dns` runs with `--label-filter` flag to select specific `Ingress` objects. Let's support ingress extra labels in `oauth2-proxy` chart.