### PR TITLE
Set the default value of entries to empty list

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.12.0
+version: 6.12.1
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -259,7 +259,7 @@ httpScheme: http
 htpasswdFile:
   enabled: false
   existingSecret: ""
-  entries: {}
+  entries: []
   # One row for each user
   # example:
   # entries:


### PR DESCRIPTION
Without this helm list gives the following warnings:
`coalesce.go:199: warning: cannot overwrite table with non table for entries (map[])
`