### PR TITLE
Use a secret instead of a configmap for alpha config

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.13.1
+version: 6.13.2
 apiVersion: v2
 appVersion: 7.4.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -108,7 +108,8 @@ Parameter | Description | Default
 `alphaConfig.metricsConfigData` | Arbitrary configuration data to append to the metrics section | `{}`
 `alphaConfig.configData` | Arbitrary configuration data to append | `{}`
 `alphaConfig.configFile` | Arbitrary configuration to append, treated as a Go template and rendered with the root context | `""`
-`alphaConfig.existingConfig` | existing Kubernetes configmap to use for the alpha configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/configmap-alpha.yaml) for the required values | `nil`
+`alphaConfig.existingConfig` | existing Kubernetes configmap to use for the alpha configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/secret-alpha.yaml) for the required values | `nil`
+`alphaConfig.existingSecret` | existing Kubernetes secret to use for the alpha configuration file. See [config template](https://github.com/oauth2-proxy/manifests/blob/master/helm/oauth2-proxy/templates/secret-alpha.yaml) for the required values | `nil`
 `customLabels` | Custom labels to add into metadata | `{}` |
 `config.google.adminEmail` | user impersonated by the google service account | `""`
 `config.google.useApplicationDefaultCredentials` | use the application-default credentials (i.e. Workload Identity on GKE) instead of providing a service account json | `false`

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -300,10 +300,17 @@ spec:
         name: configmain
 {{- end }}
 {{- if .Values.alphaConfig.enabled }}
+{{- if .Values.alphaConfig.existingConfig }}
       - configMap:
           defaultMode: 420
-          name: {{ if .Values.alphaConfig.existingConfig }}{{ .Values.alphaConfig.existingConfig }}{{ else }}{{ template "oauth2-proxy.fullname" . }}-alpha{{ end }}
+          name: {{ .Values.alphaConfig.existingConfig }}
         name: configalpha
+{{- else }}
+      - secret:
+          defaultMode: 420
+          secretName: {{ if .Values.alphaConfig.existingSecret }}{{ .Values.alphaConfig.existingSecret }}{{ else }}{{ template "oauth2-proxy.fullname" . }}-alpha{{ end }}
+        name: configalpha
+{{- end }}
 {{- end }}
 {{- if ne (len .Values.extraVolumes) 0 }}
 {{ toYaml .Values.extraVolumes | indent 6 }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.alphaConfig.enabled }}
-        checksum/alpha-config: {{ include (print $.Template.BasePath "/configmap-alpha.yaml") . | sha256sum }}
+        checksum/alpha-config: {{ include (print $.Template.BasePath "/secret-alpha.yaml") . | sha256sum }}
         {{- end }}
         checksum/config-emails: {{ include (print $.Template.BasePath "/configmap-authenticated-emails-file.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/helm/oauth2-proxy/templates/secret-alpha.yaml
+++ b/helm/oauth2-proxy/templates/secret-alpha.yaml
@@ -1,7 +1,11 @@
-{{- if .Values.alphaConfig.enabled }}
-{{- if not .Values.alphaConfig.existingConfig }}
+{{-
+  if and
+    .Values.alphaConfig.enabled
+    (not .Values.alphaConfig.existingConfig)
+    (not .Values.alphaConfig.existingSecret)
+}}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
 {{- if .Values.alphaConfig.annotations }}
   annotations: {{- toYaml .Values.alphaConfig.annotations | nindent 4 }}
@@ -11,7 +15,7 @@ metadata:
     {{- include "oauth2-proxy.labels" . | indent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}-alpha
   namespace: {{ template "oauth2-proxy.namespace" $ }}
-data:
+stringData:
   oauth2_proxy.yml: |
     ---
     server:
@@ -32,5 +36,4 @@ data:
     {{- if .Values.alphaConfig.configFile }}
     {{- tpl .Values.alphaConfig.configFile $ | nindent 4 }}
     {{- end }}
-{{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -61,8 +61,10 @@ alphaConfig:
   # Arbitrary configuration to append
   # This is treated as a Go template and rendered with the root context
   configFile: ""
-  # Use an existing config map (see configmap-alpha.yaml for required fields)
+  # Use an existing config map (see secret-alpha.yaml for required fields)
   existingConfig: ~
+  # Use an existing secret
+  existingSecret: ~
 
 image:
   repository: "quay.io/oauth2-proxy/oauth2-proxy"


### PR DESCRIPTION
This PR addresses the concerns in #104, namely that using the alpha config requires storing the client secret in a configmap, by moving the whole alpha config to a secret.

Once we have a better way of locating secrets, this can be changed.