### PR TITLE
chore(github): Generate release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,9 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: helm
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true


### PR DESCRIPTION
## What

* Enables release note generation via an [option](https://github.com/helm/chart-releaser#create-github-releases-from-helm-chart-packages) provided by chart-releaser. chart-releaser uses GitHub's feature for automatic release note generation ([docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)).

## Why

* Current release notes provided in the release are unusable with tools like [Renovate](https://github.com/renovatebot/renovate).