### PR TITLE
Upgrade to oauth2-proxy v7.5.0

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 6.16.1
+version: 6.16.2
 apiVersion: v2
-appVersion: 7.4.0
+appVersion: 7.5.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.16.2
+version: 6.17.0
 apiVersion: v2
 appVersion: 7.5.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/


### PR DESCRIPTION
Important Notes

This release includes fixes for a number of CVEs, we recommend to upgrade as soon as possible.

https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.5.0