### PR TITLE
Update oauth2-proxy to v7.5.1

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.17.2
+version: 6.17.1
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 6.17.0
+version: 6.17.2
 apiVersion: v2
-appVersion: 7.5.0
+appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:


### PR DESCRIPTION
New version of oauth2-proxy was recently released with CVE fixes - https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.5.1

> This release includes fixes for a number of CVEs, we recommend to upgrade as soon as possible.