### PR TITLE
Fix hostAliases to support multiple entries

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.18.0
+version: 6.18.1
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Redis version bump
+      description: Fix hostAliases to add multiple entries in /etc/hosts
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/165
+          url: https://github.com/oauth2-proxy/manifests/pull/164

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.25.0
+version: 7.0.0
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.18.1
+version: 6.19.0
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -123,9 +123,7 @@ Parameter | Description | Default
 `extraEnv` | key:value list of extra environment variables to give the binary | `[]`
 `extraVolumes` | list of extra volumes | `[]`
 `extraVolumeMounts` | list of extra volumeMounts | `[]`
-`hostAlias.enabled`  | provide extra ip:hostname alias for network name resolution.
-`hostAlias.ip`  | `ip` address `hostAliases.hostname` should resolve to.
-`hostAlias.hostname`  | `hostname` associated to `hostAliases.ip`.
+`hostAliases`  | hostAliases is a list of aliases to be added to /etc/hosts for network name resolution.
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`
 `htpasswdFile.entries` | list of [encrypted user:passwords](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options) | `{}`
 `htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file | `""`

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -51,11 +51,9 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "oauth2-proxy.serviceAccountName" . }}
       automountServiceAccountToken : {{ .Values.serviceAccount.automountServiceAccountToken }}
-      {{- if .Values.hostAlias.enabled }}
+      {{- if .Values.hostAliases }}
       hostAliases:
-        - ip: {{ .Values.hostAlias.ip }}
-          hostnames:
-          - {{ .Values.hostAlias.hostname }}
+        {{ toYaml .Values.hostAliases | nindent 8}}
       {{- end }}
       {{- if and .Values.redis.enabled .Values.initContainers.waitForRedis.enabled }}
       initContainers:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -192,11 +192,12 @@ extraContainers: []
 
 priorityClassName: ""
 
-# Host aliases, useful when working "on premise" where (public) DNS resolver does not know about my hosts.
-hostAlias:
-  enabled: false
-  # ip: "10.xxx.xxx.xxx"
-  # hostname: "auth.example.com"
+# hostAliases is a list of aliases to be added to /etc/hosts for network name resolution
+hostAliases: []
+# - ip: 127.0.0.1
+#   hostnames:
+#     - chart-example.local
+#     - example.local
 
 # [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) configuration.
 # Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -194,6 +194,9 @@ priorityClassName: ""
 
 # hostAliases is a list of aliases to be added to /etc/hosts for network name resolution
 hostAliases: []
+# - ip: "10.xxx.xxx.xxx"
+#   hostnames:
+#     - "auth.example.com"
 # - ip: 127.0.0.1
 #   hostnames:
 #     - chart-example.local


### PR DESCRIPTION
**Issue**: 

Current `hostAliases` [implementation](https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/templates/deployment.yaml#L56) supports only one alias entry.

It doesn't support to add two or more alias entries in /etc/hosts.

Refer: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases
We need flexibility to add multiple alias entries.