### PR TITLE
Bump: Redis chart version bumped to 18.11.5

### DIFF
--- a/helm/oauth2-proxy/Chart.lock
+++ b/helm/oauth2-proxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.13.2
-digest: sha256:6fc589816ba4670d6f38cc724cba9b728d10a041a2cef4425a62c22f9a1aa5f6
-generated: "2022-12-20T18:22:05.758522+01:00"
+  version: 18.1.5
+digest: sha256:1b36e81e2d34a33ba7aa2229bfe6216ace85789aea70f9c2d72c59d58f3a2b4f
+generated: "2023-10-17T15:27:08.54732+02:00"

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.17.1
+version: 6.17.2
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -14,7 +14,7 @@ keywords:
   - redis
 dependencies:
   - name: redis
-    version: ~16.13.2
+    version: ~18.1.5
     repository: https://charts.bitnami.com/bitnami
     alias: redis
     condition: redis.enabled
@@ -35,7 +35,4 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: securityContext and timeout of the initContainer wait-for-redis configurable via values.
-      links:
-        - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/159
+      description: Redis version bump

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -36,3 +36,6 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Redis version bump
+      links:
+        - name: Github PR
+          url: https://github.com/oauth2-proxy/manifests/pull/165

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.17.2
+version: 6.18.0
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/ci/redis-standalone-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-standalone-values.yaml
@@ -10,3 +10,6 @@ redis:
   global:
     redis:
       password: "foo"
+initContainers:
+  waitForRedis:
+    enabled: true


### PR DESCRIPTION
As mentioned in #108 the Redis subchart version is outdated and needs a bump.

This solves several security issues as well as other minor stuff. It's been tested with the Proxy and seems to work properly in our environment. 