### PR TITLE
Fix Role & Rolebinding namespace

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.20.0
+version: 6.20.1
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -34,8 +34,8 @@ maintainers:
 kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Allow specifying terminationGracePeriodSeconds and lifecycle hooks
+    - kind: fixed
+      description: Fixed service account role and rolebinding created in the wrong namespace
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/174
+          url: PENDING

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -38,4 +38,4 @@ annotations:
       description: Fixed service account role and rolebinding created in the wrong namespace
       links:
         - name: Github PR
-          url: PENDING
+          url: https://github.com/oauth2-proxy/manifests/pull/175

--- a/helm/oauth2-proxy/templates/serviceaccount.yaml
+++ b/helm/oauth2-proxy/templates/serviceaccount.yaml
@@ -24,6 +24,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $fullName }}-watch-redis
+  namespace: {{ $namespace }}
   labels:
     app: {{ $name }}
     {{- $labels | nindent 4 }}
@@ -43,6 +44,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $saName }}-watch-redis
+  namespace: {{ $namespace }}
   labels:
     app: {{ $name }}
     {{- $labels | nindent 4 }}


### PR DESCRIPTION
**Issue**

When creating a deployment with namespaceOverride variable set, the Role and Rolebinding are created in the wrong namespace. 

**Fix**

Declare explicitly the namespace in both Role and Rolebinding manifests so they always get created in the namespace set both by default and by the overrideNamespace variable