### PR TITLE
Avoid unnecessary pod restart on each helm chart version

### DIFF
--- a/helm/oauth2-proxy/Chart.lock
+++ b/helm/oauth2-proxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 18.3.3
-digest: sha256:865602aa87ca1148f943df10e3151f64e9f52cdef7be2109b6cf9774b4c356be
-generated: "2023-12-10T13:18:26.852349+01:00"
+  version: 18.3.2
+digest: sha256:c4d7208b098ca3c44f960f02fb0e505ac6493cf00c6539ee7bf0a603371d9959
+generated: "2023-11-13T12:24:54.470708+01:00"

--- a/helm/oauth2-proxy/Chart.lock
+++ b/helm/oauth2-proxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 18.3.2
-digest: sha256:c4d7208b098ca3c44f960f02fb0e505ac6493cf00c6539ee7bf0a603371d9959
-generated: "2023-11-13T12:24:54.470708+01:00"
+  version: 18.3.3
+digest: sha256:865602aa87ca1148f943df10e3151f64e9f52cdef7be2109b6cf9774b4c356be
+generated: "2023-12-10T13:18:26.852349+01:00"

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.21.2
+version: 6.22.0
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix wrong formating for resources for the wait-for-redis initContainer
+      description: Avoid unnecessary pod restart on each helm chart version
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/177
+          url: https://github.com/oauth2-proxy/manifests/pull/178

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.21.1
+version: 6.21.2
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -131,3 +131,31 @@ Workaround for EKS https://github.com/aws/eks-distro/issues/1128
 {{- printf "%s.%s" .Capabilities.KubeVersion.Major (.Capabilities.KubeVersion.Minor | replace "+" "") -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "oauth2-proxy.alpha-config" -}}
+---
+server:
+  BindAddress: '0.0.0.0:4180'
+{{- if .Values.alphaConfig.serverConfigData }}
+{{- toYaml .Values.alphaConfig.serverConfigData | nindent 6 }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+metricsServer:
+  BindAddress: '0.0.0.0:44180'
+{{- if .Values.alphaConfig.metricsConfigData }}
+{{- toYaml .Values.alphaConfig.metricsConfigData | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- if .Values.alphaConfig.configData }}
+{{- toYaml .Values.alphaConfig.configData | nindent 4 }}
+{{- end }}
+{{- if .Values.alphaConfig.configFile }}
+{{- tpl .Values.alphaConfig.configFile $ | nindent 4 }}
+{{- end }}
+{{- end -}}
+
+{{- define "oauth2-proxy.secrets" -}}
+cookie-secret: {{ tpl .Values.config.cookieSecret $ | b64enc | quote }}
+client-secret: {{ tpl .Values.config.clientSecret $ | b64enc | quote }}
+client-id: {{ tpl .Values.config.clientID $ | b64enc | quote }}
+{{- end -}}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -21,16 +21,18 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ tpl .Values.config.configFile $ | sha256sum }}
         {{- if .Values.alphaConfig.enabled }}
-        checksum/alpha-config: {{ include (print $.Template.BasePath "/secret-alpha.yaml") . | sha256sum }}
+        checksum/alpha-config: {{ include "oauth2-proxy.alpha-config" . | sha256sum }}
         {{- end }}
+        {{- if .Values.authenticatedEmailsFile.enabled }}
         checksum/config-emails: {{ include (print $.Template.BasePath "/configmap-authenticated-emails-file.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        checksum/secret: {{ include "oauth2-proxy.secrets" . | sha256sum }}
         checksum/google-secret: {{ include (print $.Template.BasePath "/google-secret.yaml") . | sha256sum }}
         checksum/redis-secret: {{ include (print $.Template.BasePath "/redis-secret.yaml") . | sha256sum }}
 {{- if .Values.htpasswdFile.enabled }}
-        checksum/htpasswd: {{ include (print $.Template.BasePath "/secret-htpasswd-file.yaml") . | sha256sum }}
+        checksum/htpasswd: {{ toYaml .Values.htpasswdFile.entries | sha256sum }}
 {{- end }}
     {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/helm/oauth2-proxy/templates/secret-alpha.yaml
+++ b/helm/oauth2-proxy/templates/secret-alpha.yaml
@@ -15,25 +15,6 @@ metadata:
     {{- include "oauth2-proxy.labels" . | indent 4 }}
   name: {{ template "oauth2-proxy.fullname" . }}-alpha
   namespace: {{ template "oauth2-proxy.namespace" $ }}
-stringData:
-  oauth2_proxy.yml: |
-    ---
-    server:
-      BindAddress: '0.0.0.0:4180'
-    {{- if .Values.alphaConfig.serverConfigData }}
-    {{- toYaml .Values.alphaConfig.serverConfigData | nindent 6 }}
-    {{- end }}
-    {{- if .Values.metrics.enabled }}
-    metricsServer:
-      BindAddress: '0.0.0.0:44180'
-    {{- if .Values.alphaConfig.metricsConfigData }}
-    {{- toYaml .Values.alphaConfig.metricsConfigData | nindent 6 }}
-    {{- end }}
-    {{- end }}
-    {{- if .Values.alphaConfig.configData }}
-    {{- toYaml .Values.alphaConfig.configData | nindent 4 }}
-    {{- end }}
-    {{- if .Values.alphaConfig.configFile }}
-    {{- tpl .Values.alphaConfig.configFile $ | nindent 4 }}
-    {{- end }}
+data:
+  oauth2_proxy.yml: {{ include "oauth2-proxy.alpha-config" . | b64enc | quote }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/secret.yaml
+++ b/helm/oauth2-proxy/templates/secret.yaml
@@ -13,7 +13,5 @@ metadata:
   namespace: {{ template "oauth2-proxy.namespace" $ }}
 type: Opaque
 data:
-  cookie-secret: {{ tpl .Values.config.cookieSecret $ | b64enc | quote }}
-  client-secret: {{ tpl .Values.config.clientSecret $ | b64enc | quote }}
-  client-id: {{ tpl .Values.config.clientID $ | b64enc | quote }}
+{{- include "oauth2-proxy.secrets" . | nindent 2 }}
 {{- end -}}


### PR DESCRIPTION
This PR changes the the input of the config checksum which triggers the reload.

On main branch, the whole configmap/secret checksum is included as checksum input. The configmap contains labels which includes the helm chart version. Each new helm chart version forces a pod restart which is not always necessary.

By define a finer input for the pod annotation checksum, unnecessary pod restarts can be avoided.

The PR implements this for

* config
* alpha config
* secrets
* htpasswd

and could be extended to

* redis
* email
* google secret