### PR TITLE
Bump redis chart version

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.21.1
+version: 6.22.0
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -14,7 +14,7 @@ keywords:
   - redis
 dependencies:
   - name: redis
-    version: ~18.3.2
+    version: ~18.5.0
     repository: https://charts.bitnami.com/bitnami
     alias: redis
     condition: redis.enabled


### PR DESCRIPTION
Bumping Redis subchart to 18.5.0, which adds the capability to deploy Redis in a different namespace, if desired, using the following variable:

``` yaml
redis:
    namespaceOverride:
```
