### PR TITLE
Fix indentation in alpha config

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 6.23.0
+version: 6.23.1
 apiVersion: v2
 appVersion: 7.5.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Avoid unnecessary pod restart on each helm chart version
+      description: Fix indentation in alpha config
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/178
+          url: https://github.com/oauth2-proxy/manifests/pull/180

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -137,20 +137,20 @@ Workaround for EKS https://github.com/aws/eks-distro/issues/1128
 server:
   BindAddress: '0.0.0.0:4180'
 {{- if .Values.alphaConfig.serverConfigData }}
-{{- toYaml .Values.alphaConfig.serverConfigData | nindent 6 }}
+{{- toYaml .Values.alphaConfig.serverConfigData | nindent 2 }}
 {{- end }}
 {{- if .Values.metrics.enabled }}
 metricsServer:
   BindAddress: '0.0.0.0:44180'
 {{- if .Values.alphaConfig.metricsConfigData }}
-{{- toYaml .Values.alphaConfig.metricsConfigData | nindent 6 }}
+{{- toYaml .Values.alphaConfig.metricsConfigData | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- if .Values.alphaConfig.configData }}
-{{- toYaml .Values.alphaConfig.configData | nindent 4 }}
+{{- toYaml .Values.alphaConfig.configData | nindent 0 }}
 {{- end }}
 {{- if .Values.alphaConfig.configFile }}
-{{- tpl .Values.alphaConfig.configFile $ | nindent 4 }}
+{{- tpl .Values.alphaConfig.configFile $ | nindent 0 }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
The indentation in the generated alpha configuration is wrong after some restructuring in bffe63ed86dcdc6c7933d47e5270b9047dfebed9.