### PR TITLE
Upgrade to the latest version of OAuth2-Proxy

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 6.23.1
+version: 6.24.0
 apiVersion: v2
-appVersion: 7.5.1
+appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
@@ -34,8 +34,8 @@ maintainers:
 kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix indentation in alpha config
+    - kind: added
+      description: Upgrade to the latest version of the software
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/180
+          url: https://github.com/oauth2-proxy/manifests/pull/184


### PR DESCRIPTION
The new version of `oauth2-proxy` was recently released: https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.6.0