### PR TITLE
Fix indentation in ServiceMonitor tlsConfig

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.4.1
+version: 7.4.2
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Fix link in readme to existingSecret needed fields
+      description: Fix indentation in ServiceMonitor tlsConfig
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/193
+          url: https://github.com/oauth2-proxy/manifests/pull/200

--- a/helm/oauth2-proxy/templates/servicemonitor.yaml
+++ b/helm/oauth2-proxy/templates/servicemonitor.yaml
@@ -44,7 +44,7 @@ spec:
     {{- end }}
     {{- with .Values.metrics.serviceMonitor.tlsConfig }}
     tlsConfig:
-      {{- toYaml .| nindent 4 }}
+      {{- toYaml .| nindent 6 }}
     {{- end }}
     {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
     metricRelabelings:


### PR DESCRIPTION
Fixes incorrect indentation in ServiceMonitor.

Closes https://github.com/oauth2-proxy/manifests/issues/199