### PR TITLE
Add option to add config via envFrom

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.4.1
+version: 7.4.3
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Fix link in readme to existingSecret needed fields
+      description: Support envFrom as way to configure Pod
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/193
+          url: https://github.com/oauth2-proxy/manifests/issues/198

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -211,6 +211,10 @@ spec:
         {{- if .Values.extraEnv }}
 {{ tpl (toYaml .Values.extraEnv) . | indent 8 }}
         {{- end }}
+        {{- if .Values.envFrom }}
+        envFrom:
+{{ tpl (toYaml .Values.envFrom) . | indent 8 }}
+        {{- end }}
         ports:
         {{- if .Values.containerPort }}
           - containerPort: {{ .Values.containerPort }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -86,6 +86,19 @@ image:
 extraArgs: {}
 extraEnv: []
 
+envFrom: []
+# Load environment variables from a ConfigMap(s) and/or Secret(s)
+# that already exists (created and managed by you).
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+#
+# PS: Changes in these ConfigMaps or Secrets will not be automatically
+#     detected and you must manually restart the relevant Pods after changes.
+#
+#  - configMapRef:
+#      name: special-config
+#  - secretRef:
+#      name: special-config-secret
+
 # -- Custom labels to add into metadata
 customLabels: {}
 


### PR DESCRIPTION
Add option to add config via envFrom 

I opted for having the configuration with the full format:

```
- configMapRef:
      name: special-config
```

since the [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#envfromsource-v1-core) allows for both ConfigMaps and Secrets. This makes using it a bit more verbose, but the template-logic much simpler than iterating over two lists (one for ConfigMaps and one for Secrets).

Closes https://github.com/oauth2-proxy/manifests/issues/198