### PR TITLE
Redis cluster.enabled parameter is deprecated in bitnami's 14.0.0

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -38,4 +38,4 @@ annotations:
       description: Redis parameters update in values
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/issues/203
+          url: https://github.com/oauth2-proxy/manifests/issues/202

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.5.2
+version: 7.5.3
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Support envFrom as way to configure Pod
+      description: Redis parameters update in values
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/issues/198
+          url: https://github.com/oauth2-proxy/manifests/pull/202

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -38,4 +38,4 @@ annotations:
       description: Redis parameters update in values
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/202
+          url: https://github.com/oauth2-proxy/manifests/issues/203

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -354,9 +354,7 @@ redis:
   # Redis specific helm chart settings, please see:
   # https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters
   # redisPort: 6379
-  # cluster:
-  #   enabled: false
-  #   slaveCount: 1
+  # architecture: standalone
 
 # Enables apiVersion deprecation checks
 checkDeprecation: true


### PR DESCRIPTION
> cluster.enabled parameter is deprecated in favor of architecture parameter that accepts two values: standalone and replication.

https://github.com/bitnami/charts/tree/main/bitnami/redis#to-1400
