### PR TITLE
fix: deployment annotation indentation

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.6.1
+version: 7.6.2
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed test for horizontal autoscaling feature
+      description: Fixed deployment annotation indentation
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/211
+          url: https://github.com/oauth2-proxy/manifests/pull/204

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
 {{- include "oauth2-proxy.labels" . | indent 4 }}
   {{- if .Values.deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.deploymentAnnotations | indent 8 }}
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
   {{- end }}
   name: {{ template "oauth2-proxy.fullname" . }}
   namespace: {{ template "oauth2-proxy.namespace" $ }}


### PR DESCRIPTION
This pull request includes a minor change to the `helm/oauth2-proxy/templates/deployment.yaml` file. The change modifies the indentation level of the `deploymentAnnotations` from 8 spaces to 4 spaces in the `annotations` section of the `metadata`. This adjustment ensures the correct formatting of the YAML file.