### PR TITLE
fix: use the correct default configmap name in deployment

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.6.1
+version: 7.6.3
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed test for horizontal autoscaling feature
+      description: Fix the default configmap name in deployment
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/211
+          url: https://github.com/oauth2-proxy/manifests/pull/210

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
         {{- if .Values.authenticatedEmailsFile.template }}
           - --authenticated-emails-file=/etc/oauth2-proxy/{{ .Values.authenticatedEmailsFile.template }}
         {{- else }}
-          - --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails-list
+          - --authenticated-emails-file=/etc/oauth2-proxy/{{ template "oauth2-proxy.fullname" . }}-accesslist
         {{- end }}
         {{- end }}
         {{- with .Values.config.google }}
@@ -381,7 +381,7 @@ spec:
 {{- if .Values.authenticatedEmailsFile.template }}
             path: {{ .Values.authenticatedEmailsFile.template }}
 {{- else }}
-            path: authenticated-emails-list
+            path: {{ template "oauth2-proxy.fullname" . }}-accesslist
 {{- end }}
         name: configaccesslist
 {{- end }}


### PR DESCRIPTION
If you wish to use the default config map and only supply emails in `authenticatedEmailsFile.restricted_users` option, the chart doesn't include the proper reference to the default config map name. See below:

https://github.com/oauth2-proxy/manifests/blob/6116131b136697e10dda185eaed2bdda347b2d33/helm/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml#L13