### PR TITLE
fix: Deployment name in HPAs scaleTargeRef spec

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.7.4
+version: 7.7.5
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed the path in the volume "configaccesslist"
+      description: Fixed the Deployment name in HPAs scaleTargeRef spec
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/216
+          url: https://github.com/oauth2-proxy/manifests/pull/217

--- a/helm/oauth2-proxy/templates/hpa.yaml
+++ b/helm/oauth2-proxy/templates/hpa.yaml
@@ -15,7 +15,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "oauth2-proxy.name" . }}
+    name: {{ template "oauth2-proxy.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
The Deployment name in `helm/oauth2-proxy/templates/deployment.yaml` is configured with `{{ template "oauth2-proxy.fullname" . }}` which can cause `Deployment not found` issues when the default Release name is overwritten.