### PR TITLE
fix: Reorder metrics list in HPA

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -38,4 +38,4 @@ annotations:
       description: Reorder metrics list in HPA to avoid reconciliation loops with Argo CD
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/219
+          url: https://github.com/oauth2-proxy/manifests/pull/220

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.7.6
+version: 7.7.7
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -35,7 +35,7 @@ kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Updated the Redis chart to the latest version
+      description: Reorder metrics list in HPA to avoid reconciliation loops with Argo CD
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/218
+          url: https://github.com/oauth2-proxy/manifests/pull/219

--- a/helm/oauth2-proxy/templates/hpa.yaml
+++ b/helm/oauth2-proxy/templates/hpa.yaml
@@ -19,14 +19,6 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -34,5 +26,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
This fixes reconciliation loops in Argo CD because HPA controller reorders the list entries.
The observed behaviour is described in the following issue: https://github.com/kubernetes/kubernetes/issues/74099