### PR TITLE
Support templating of `extraVolumes`

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.7.9
+version: 7.7.10
 apiVersion: v2
 appVersion: 7.6.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/helm/oauth2-proxy/ci/tpl-values.yaml
+++ b/helm/oauth2-proxy/ci/tpl-values.yaml
@@ -19,3 +19,11 @@ pass_authorization_header: "true"
 
 extraArgs:
   pass-authorization-header: "{{ $.Values.pass_authorization_header }}"
+
+extraVolumes:
+  - name: "{{ $.Release.Name }}-secret"
+    secret:
+      secretName: "{{ .Release.Name }}-secret"
+      items:
+        - key: secret
+          path: secret

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -369,7 +369,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if ne (len .Values.extraVolumes) 0 }}
-{{ toYaml .Values.extraVolumes | indent 6 }}
+{{ tpl (toYaml .Values.extraVolumes) . | indent 6 }}
 {{- end }}
 {{- if and (.Values.authenticatedEmailsFile.enabled) (eq .Values.authenticatedEmailsFile.persistence "configmap") }}
       - configMap:


### PR DESCRIPTION
Hi,

It would be useful to support templating of the `extraVolumes` list to allow us to have secrets named with a `{{ .Release.Name }}` prefix in blue-green deployments.

Let me know if any additional changes are required!