### PR TITLE
Update oauth2-proxy to v7.7.0

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 7.7.22
+version: 7.7.23
 apiVersion: v2
-appVersion: 7.6.0
+appVersion: 7.7.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:


### PR DESCRIPTION
New version of oauth2-proxy was recently released with CVE fixes.

https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.7.0