### PR TITLE
chore: 'check-redis.sh' script accounts for rediss:// scheme

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.7.27
+version: 7.7.28
 apiVersion: v2
 appVersion: 7.7.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -34,8 +34,8 @@ maintainers:
 kubeVersion: ">=1.9.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Updated the Redis chart to the latest version.
+    - kind: added
+      description: Added support for 'rediss://' scheme in 'check-redis.sh' script
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/247
+          url: https://github.com/oauth2-proxy/manifests/pull/249

--- a/helm/oauth2-proxy/scripts/check-redis.sh
+++ b/helm/oauth2-proxy/scripts/check-redis.sh
@@ -24,7 +24,16 @@ check_redis() {
 # For parsing and checking connections
 parse_and_check() {
     url=$1
-    clean_url=${url#redis://}
+
+    # Strip either redis:// or rediss://
+    if [[ $url == rediss://* ]]; then
+        clean_url=${url#rediss://}
+        echo "Using secure Rediss connection..."
+    else
+        clean_url=${url#redis://}
+        echo "Using standard Redis connection..."
+    fi
+
     host=$(echo $clean_url | cut -d':' -f1)
     port=$(echo $clean_url | cut -d':' -f2)
     check_redis $host $port


### PR DESCRIPTION
Proposed improvement following #248: check-redis.sh script does not account for "rediss://" scheme