### PR TITLE
fix: connection urls to be automatically comma separated

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Prometheus Operator CRDs
         id: prom
-        run: kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.78/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+        run: kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.80.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.10.3
+version: 7.10.4
 apiVersion: v2
 appVersion: 7.8.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -31,8 +31,8 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: update helm release redis to v20.6.3
+    - kind: fixed
+      description: automatically concatenate connectionUrls with comma
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/279
+          url: https://github.com/oauth2-proxy/manifests/pull/268

--- a/helm/oauth2-proxy/ci/redis-sentinel-array-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-sentinel-array-values.yaml
@@ -1,0 +1,24 @@
+sessionStorage:
+  type: redis
+  redis:
+    clientType: sentinel
+    sentinel:
+      password: "foo"
+      masterName: "mymaster"
+      connectionUrls:
+        - "redis://oauth2-proxy-redis:26379"
+        - "redis://oauth2-proxy-redis:26379"
+redis:
+  # provision an instance of the redis sub-chart
+  enabled: true
+  fullnameOverride: oauth2-proxy-redis
+  architecture: replication
+  sentinel:
+    enabled: true
+    masterSet: mymaster
+  global:
+    redis:
+      password: "foo"
+initContainers:
+  waitForRedis:
+    enabled: true

--- a/helm/oauth2-proxy/ci/redis-sentinel-comma-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-sentinel-comma-values.yaml
@@ -1,0 +1,22 @@
+sessionStorage:
+  type: redis
+  redis:
+    clientType: sentinel
+    sentinel:
+      password: "foo"
+      masterName: "mymaster"
+      connectionUrls: "redis://oauth2-proxy-redis:26379,redis://oauth2-proxy-redis:26379"
+redis:
+  # provision an instance of the redis sub-chart
+  enabled: true
+  fullnameOverride: oauth2-proxy-redis
+  architecture: replication
+  sentinel:
+    enabled: true
+    masterSet: mymaster
+  global:
+    redis:
+      password: "foo"
+initContainers:
+  waitForRedis:
+    enabled: true

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -79,12 +79,12 @@ spec:
         - name: OAUTH2_PROXY_REDIS_USE_CLUSTER
           value: "true"
         - name: OAUTH2_PROXY_REDIS_CLUSTER_CONNECTION_URLS
-          value: {{ .Values.sessionStorage.redis.cluster.connectionUrls }}
+          value: {{ join "," .Values.sessionStorage.redis.cluster.connectionUrls }}
         {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "sentinel" }}
         - name: OAUTH2_PROXY_REDIS_USE_SENTINEL
           value: "true"
         - name: OAUTH2_PROXY_REDIS_SENTINEL_CONNECTION_URLS
-          value: {{ .Values.sessionStorage.redis.sentinel.connectionUrls }}
+          value: {{ join "," .Values.sessionStorage.redis.sentinel.connectionUrls }}
         {{- end }}
       {{- if .Values.initContainers.waitForRedis.securityContext.enabled }}
       {{- $securityContext := unset .Values.initContainers.waitForRedis.securityContext "enabled" }}
@@ -213,14 +213,14 @@ spec:
         - name: OAUTH2_PROXY_REDIS_USE_CLUSTER
           value: "true"
         - name: OAUTH2_PROXY_REDIS_CLUSTER_CONNECTION_URLS
-          value: {{ .Values.sessionStorage.redis.cluster.connectionUrls }}
+          value: {{ join "," .Values.sessionStorage.redis.cluster.connectionUrls }}
         {{- else if eq (default "" .Values.sessionStorage.redis.clientType) "sentinel" }}
         - name: OAUTH2_PROXY_REDIS_USE_SENTINEL
           value: "true"
         - name: OAUTH2_PROXY_REDIS_SENTINEL_MASTER_NAME
           value: {{ .Values.sessionStorage.redis.sentinel.masterName }}
         - name: OAUTH2_PROXY_REDIS_SENTINEL_CONNECTION_URLS
-          value: {{ .Values.sessionStorage.redis.sentinel.connectionUrls }}
+          value: {{ join "," .Values.sessionStorage.redis.sentinel.connectionUrls }}
         {{- if or .Values.sessionStorage.redis.sentinel.existingSecret .Values.sessionStorage.redis.existingSecret .Values.sessionStorage.redis.sentinel.password }}
         - name: OAUTH2_PROXY_REDIS_SENTINEL_PASSWORD
           valueFrom:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -371,8 +371,10 @@ sessionStorage:
       # URL of redis standalone server for redis session storage (e.g. `redis://HOST[:PORT]`). Automatically generated if not set
       connectionUrl: ""
     cluster:
-      # List of Redis cluster connection URLs (e.g. `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`)
+      # List of Redis cluster connection URLs. Array or single string allowed.
       connectionUrls: []
+      # - "redis://127.0.0.1:8000"
+      # - "redis://127.0.0.1:8001"
     sentinel:
       # Name of the Kubernetes secret containing the redis sentinel password value (see also `sessionStorage.redis.sentinel.passwordKey`). Default: `sessionStorage.redis.existingSecret`
       existingSecret: ""
@@ -382,8 +384,10 @@ sessionStorage:
       passwordKey: "redis-sentinel-password"
       # Redis sentinel master name
       masterName: ""
-      # List of Redis sentinel connection URLs (e.g. `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`)
+      # List of Redis cluster connection URLs. Array or single string allowed.
       connectionUrls: []
+      # - "redis://127.0.0.1:8000"
+      # - "redis://127.0.0.1:8001"
 
 # Enables and configure the automatic deployment of the redis subchart
 redis:


### PR DESCRIPTION
## Description
The `connectionUrls` attribute of `sessionStorage.redis.cluster` and `sessionStorage.redis.sentinel` is currently of type array which doesn't work.

## Solution
Add `join ","` to the templating to automatically generate a comma separated string and allow for single string values as well.