### PR TITLE
Fixed incorrect helm template syntax in README.md

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.9.0
+version: 7.9.1
 apiVersion: v2
 appVersion: 7.7.1
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -34,8 +34,8 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: allow requests to be directed to sidecar first
+    - kind: fixed
+      description: fixed incorrect helm template syntax in readme.md
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/270
+          url: https://github.com/oauth2-proxy/manifests/pull/274

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -332,7 +332,7 @@ extraObjects:
         <html>
         <body>
         <h1>error</h1>
-        <p>{{.StatusCode}}</p>
+        <p>{{`{{ .StatusCode }}`}}</p>
         </body>
         </html>
 ```


### PR DESCRIPTION
Helm uses `{{ }}` for its own templating, which can conflict with the Go templating syntax used in OAuth2 Proxy's templates. This change will make it working.