### PR TITLE
chore: update oauth2-proxy to v7.8.0

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 7.9.2
+version: 7.10.0
 apiVersion: v2
-appVersion: 7.7.1
+appVersion: 7.8.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
@@ -35,7 +35,7 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: fixed incorrect helm template syntax in readme.md
+      description: update oauth2-proxy to v7.8.0
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/274
+          url: https://github.com/oauth2-proxy/manifests/pull/276

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -34,7 +34,7 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
+    - kind: changed
       description: update oauth2-proxy to v7.8.0
       links:
         - name: Github PR


### PR DESCRIPTION
New version of oauth2-proxy was just released with CVE fixes and other changes.

https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.8.0