### PR TITLE
Solve the problem with upstreams being prohibited when alphaconfig is enabled

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 7.12.10
+version: 7.12.11
 apiVersion: v2
 appVersion: 7.8.2
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -32,7 +32,7 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Updated the Redis chart to the latest version
+      description: Solve the problem with upstreams being prohibited when alphaconfig is enabled
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/303
+          url: https://github.com/oauth2-proxy/manifests/pull/301

--- a/helm/oauth2-proxy/templates/configmap.yaml
+++ b/helm/oauth2-proxy/templates/configmap.yaml
@@ -13,6 +13,13 @@ metadata:
   name: {{ template "oauth2-proxy.fullname" . }}
   namespace: {{ template "oauth2-proxy.namespace" $ }}
 data:
+  {{- if and (not .Values.alphaConfig.enabled) .Values.config.legacyDefaults }}
+  oauth2_proxy.cfg: |-
+{{ tpl .Values.config.legacyDefaults $ | indent 4 }}
+
+{{ tpl .Values.config.configFile $ | indent 4 }}
+  {{- else }}
   oauth2_proxy.cfg: {{ tpl .Values.config.configFile $ | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -43,10 +43,18 @@ config:
     # Example:
     #  - group1@example.com
     #  - group2@example.com
+
+  # these exist only because if alphaConfig.enabled is not set then the
+  # defaults there need to be present here. If it is set, then the defaults can
+  # not be here because they're not valid. This should go away when alphaConfig
+  # is default on.
+  # https://github.com/oauth2-proxy/manifests/issues/226
+  legacyDefaults: |-
+    upstreams = [ "file:///dev/null" ]
+
   # Default configuration, to be overridden
   configFile: |-
     email_domains = [ "*" ]
-    upstreams = [ "file:///dev/null" ]
   # Custom configuration file: oauth2_proxy.cfg
   # configFile: |-
   #   pass_basic_auth = false
@@ -64,7 +72,9 @@ alphaConfig:
   # Arbitrary configuration data to append to the metrics section
   metricsConfigData: {}
   # Arbitrary configuration data to append
-  configData: {}
+  configData:
+    upstreams:
+      - "file:///dev/null"
   # Arbitrary configuration to append
   # This is treated as a Go template and rendered with the root context
   configFile: ""


### PR DESCRIPTION
Upstreams is no longer allowed if you have alphaConfig enabled, because the option is available in alphaConfig. However, setting the default in alphaConfig won't work, because people may have it disabled, and it's disabled by default.

This means we need this value to remain in configFile as a default if alphaConfig isn't enabled.

https://github.com/oauth2-proxy/manifests/issues/226