### PR TITLE
Render nodeSelector without whitespace

### DIFF
--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -410,7 +410,7 @@ spec:
     {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
Noted during a recent update of our component that when setting the `nodeSelector` value the manifests are rendered with a newline. 

Providing:

```
        nodeSelector:
          key: value
```

yeilds the following in rendered manifests:

```
      nodeSelector:
        
        key: value
```


