### PR TITLE
Support IPv4/IPv6 dual-stack

### DIFF
--- a/helm/oauth2-proxy/templates/service.yaml
+++ b/helm/oauth2-proxy/templates/service.yaml
@@ -59,3 +59,7 @@ spec:
     {{- end }}
   selector:
     {{- include "oauth2-proxy.selectorLabels" . | indent 4 }}
+{{- if .Values.service.ipDualStack.enabled }}
+  ipFamilies: {{ toYaml .Values.service.ipDualStack.ipFamilies | nindent 4 }}
+  ipFamilyPolicy: {{ .Values.service.ipDualStack.ipFamilyPolicy }}
+{{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -155,6 +155,12 @@ service:
   internalTrafficPolicy: ""
   # configure service target port
   targetPort: ""
+  # Configures the service to use IPv4/IPv6 dual-stack.
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+  ipDualStack:
+    enabled: false
+    ipFamilies: ["IPv6", "IPv4"]
+    ipFamilyPolicy: "PreferDualStack"
 
 ## Create or use ServiceAccount
 serviceAccount:


### PR DESCRIPTION
This PR adds support for IPv4/IPv6 dual-stack ([ref](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)).