### PR TITLE
fix: redis-ha subchart deployment / service name in template helpers

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 8.0.0
+version: 8.0.1
 apiVersion: v2
 appVersion: 7.11.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -31,8 +31,8 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Replace Redis chart by bitnami with dandydeveloper/redis-ha chart
+    - kind: fixed
+      description: Fixes how the fullname for the deployment / service of the newly introduced redis-ha subchart is generated
       links:
         - name: Github PR
-          url: https://github.com/oauth2-proxy/manifests/pull/335
+          url: https://github.com/oauth2-proxy/manifests/pull/338

--- a/helm/oauth2-proxy/ci/redis-standalone-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-standalone-values.yaml
@@ -7,7 +7,6 @@ sessionStorage:
 # provision an instance of the redis-ha sub-chart
 redis:
   enabled: true
-  fullnameOverride: oauth2-proxy-redis
 
   redisPassword: "foo"
 

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Redis subcharts fullname
 */}}
 {{- define "oauth2-proxy.redis.fullname" -}}
 {{- if .Values.redis.enabled -}}
-{{- include "redis-ha.fullname" (dict "Chart" (dict "Name" "redis-ha") "Release" .Release "Values" .Values.redis) -}}
+{{- include "redis-ha.fullname" (dict "Chart" (dict "Name" "redis") "Release" .Release "Values" .Values.redis) -}}
 {{- else -}}
 {{ fail "attempting to use redis subcharts fullname, even though the subchart is not enabled. This will lead to misconfiguration" }}
 {{- end -}}


### PR DESCRIPTION
This PR introduces a fix for how the new redis-ha subchart name is used when generating the Redis fullname, which was introduced in v8.0.0.

Fix: #337