### PR TITLE
Lock default image version

### DIFF
--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -77,7 +77,7 @@ alphaConfig:
 image:
   repository: "quay.io/oauth2-proxy/oauth2-proxy"
   # appVersion is used by default
-  tag: ""
+  tag: v7.11.0
   pullPolicy: "IfNotPresent"
   command: []
 


### PR DESCRIPTION
Expecting renovate helm-values manager to regularly propose bumps the container image version.

See https://docs.renovatebot.com/modules/manager/helm-values/

In this PR the N-1 version (v7.11.0) is used to demonstrate bump by renovate, with a a sample PR at https://github.com/orange-cloudfoundry/oauth2-proxy-manifests/pull/2 that includes release notes from oauth2-proxy

Fixes https://github.com/oauth2-proxy/manifests/issues/354