### PR TITLE
fix: recommended setting for redis when using 1 replica

### DIFF
--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -492,6 +492,7 @@ redis-ha:
   # Recommended:
   #
   # redisPassword: xxxxx
+  # When using replicas: 1, you MUST also set min-replicas-to-write: 0
   # replicas: 1
   # redis:
   #   config:


### PR DESCRIPTION
Hello,

To use only 1 replicas, we need to update the redis configuration `min-replicas-to-write` to 0 otherwise we have the error message "NOREPLICAS Not enough good replicas to write".

Ref: https://stackoverflow.com/a/59737862

Note: It's well configured in the CI : https://github.com/oauth2-proxy/manifests/blob/3832a76bd98c42d787da8e2069ecdbdda45c4b5f/helm/oauth2-proxy/ci/redis-standalone-values.yaml#L29
It's just missing in the doc