### PR TITLE
chore(dep): bump app version to v7.15.1

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 10.4.0
+version: 10.4.1
 apiVersion: v2
 appVersion: 7.15.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -30,23 +30,8 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Restructured config.configFile generation to support alphaConfig without conflicts
+    - kind: changed
+      description: Bump OAuth2 Proxy image to v7.15.1
       links:
-        - name: GitHub Issue
-          url: https://github.com/oauth2-proxy/manifests/issues/226
-    - kind: added
-      description: Added structured configuration with config.emailDomains and config.upstreams for better flexibility
-      links:
-        - name: GitHub Issue
-          url: https://github.com/oauth2-proxy/manifests/issues/226
-    - kind: added
-      description: Added config.forceLegacyConfig flag for users with custom configFile when using alphaConfig
-      links:
-        - name: GitHub Issue
-          url: https://github.com/oauth2-proxy/manifests/issues/226
-    - kind: added
-      description: Added comprehensive alphaConfig examples with upstreamConfig configuration
-      links:
-        - name: GitHub Issue
-          url: https://github.com/oauth2-proxy/manifests/issues/311
+        - name: GitHub PR
+          url: https://github.com/oauth2-proxy/manifests/pull/403


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Bump OAuth2 Proxy version to v7.15.1

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have bumped the version in the Chart.yaml according to [Semantic Versioning](https://semver.org).
- [X] I have updated the documentation/CHANGELOG at the bottom of the Chart.yaml
- [X] I have [signed off](https://github.com/apps/dco) all my commits.
- [ ] (Optional) I have updated the Chart.lock for dependency updates
- [ ] (Optional) I have implemented helm tests for new feature flags
