### PR TITLE
fix: add no-config legacy mode for external config management

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -30,8 +30,8 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump OAuth2 Proxy image to v7.15.2
+    - kind: fixed
+      description: Add no-config legacy mode for external config management
       links:
         - name: GitHub PR
-          url: https://github.com/oauth2-proxy/manifests/pull/406
+          url: https://github.com/oauth2-proxy/manifests/pull/404

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 10.4.3
+version: 10.5.0
 apiVersion: v2
 appVersion: 7.15.2
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -30,7 +30,7 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
+    - kind: added
       description: Add no-config legacy mode for external config management
       links:
         - name: GitHub PR

--- a/helm/oauth2-proxy/ci/no-config-values.yaml
+++ b/helm/oauth2-proxy/ci/no-config-values.yaml
@@ -1,0 +1,6 @@
+# Test: no legacy config generation (external config management)
+# Expected: No ConfigMap generated, no --config flag, no config volume mount.
+# Use case: config managed externally via CSI SecretStore Driver or similar.
+
+config:
+  forceLegacyConfig: false

--- a/helm/oauth2-proxy/ci/no-config-values.yaml
+++ b/helm/oauth2-proxy/ci/no-config-values.yaml
@@ -1,6 +1,13 @@
 # Test: no legacy config generation (external config management)
 # Expected: No ConfigMap generated, no --config flag, no config volume mount.
 # Use case: config managed externally via CSI SecretStore Driver or similar.
+#
+# Since no config file is mounted, the minimum required settings
+# (email-domain, upstream) must be provided via extraArgs.
 
 config:
   forceLegacyConfig: false
+
+extraArgs:
+  email-domain: "*"
+  upstream: "file:///dev/null"

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -164,9 +164,13 @@ metricsServer:
 {{- end -}}
 
 {{/*
-If `config.forceLegacyConfig=false`, the chart ignores both the `config.configFile` and `config.existingConfig` overrides and only generates a minimal necessary legacy config.
-If `config.existingConfig` is set and `config.forceLegacyConfig=true`, the external ConfigMap is mounted into the mounted file.
-If `config.configFile` is set and `config.forceLegacyConfig=true`, the chart renders that inline content into the mounted file.
+Legacy config mode resolution:
+- alphaConfig.enabled=true + forceLegacyConfig=false → generated-alpha-compatible (minimal legacy config)
+- config.existingConfig is set → existing-configmap (external ConfigMap, regardless of forceLegacyConfig)
+- config.configFile is set → inline-custom (user-provided content, regardless of forceLegacyConfig)
+- alphaConfig.enabled=true (with forceLegacyConfig=true) → generated-alpha-compatible
+- alphaConfig.enabled=false + forceLegacyConfig=false + no configFile/existingConfig → no-config (nothing generated/mounted)
+- Default → generated-legacy (full legacy config with emailDomains + upstreams)
 */}}
 {{- define "oauth2-proxy.legacy-config.mode" -}}
 {{- if and .Values.alphaConfig.enabled (not .Values.config.forceLegacyConfig) -}}

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -165,12 +165,18 @@ metricsServer:
 
 {{/*
 Legacy config mode resolution:
-- alphaConfig.enabled=true + forceLegacyConfig=false → generated-alpha-compatible (minimal legacy config)
-- config.existingConfig is set → existing-configmap (external ConfigMap, regardless of forceLegacyConfig)
-- config.configFile is set → inline-custom (user-provided content, regardless of forceLegacyConfig)
-- alphaConfig.enabled=true (with forceLegacyConfig=true) → generated-alpha-compatible
-- alphaConfig.enabled=false + forceLegacyConfig=false + no configFile/existingConfig → no-config (nothing generated/mounted)
-- Default → generated-legacy (full legacy config with emailDomains + upstreams)
+- alphaConfig.enabled=true + forceLegacyConfig=false
+    → generated-alpha-compatible (minimal legacy config; config.existingConfig and config.configFile are ignored)
+- config.existingConfig is set (only when NOT in alphaConfig.enabled + !forceLegacyConfig path)
+    → existing-configmap (external ConfigMap)
+- config.configFile is set (only when NOT in alphaConfig.enabled + !forceLegacyConfig path)
+    → inline-custom (user-provided content)
+- alphaConfig.enabled=true + forceLegacyConfig=true (no existingConfig/configFile)
+    → generated-alpha-compatible
+- alphaConfig.enabled=false + forceLegacyConfig=false + no configFile/existingConfig
+    → no-config (nothing generated/mounted)
+- Default
+    → generated-legacy (full legacy config with emailDomains + upstreams)
 */}}
 {{- define "oauth2-proxy.legacy-config.mode" -}}
 {{- if and .Values.alphaConfig.enabled (not .Values.config.forceLegacyConfig) -}}

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -177,6 +177,8 @@ existing-configmap
 inline-custom
 {{- else if .Values.alphaConfig.enabled -}}
 generated-alpha-compatible
+{{- else if not .Values.config.forceLegacyConfig -}}
+no-config
 {{- else -}}
 generated-legacy
 {{- end -}}

--- a/helm/oauth2-proxy/templates/configmap.yaml
+++ b/helm/oauth2-proxy/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if ne (include "oauth2-proxy.legacy-config.mode" .) "existing-configmap" }}
+{{- if not (has (include "oauth2-proxy.legacy-config.mode" .) (list "existing-configmap" "no-config")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $legacyConfigMode := include "oauth2-proxy.legacy-config.mode" . -}}
 {{- $redisEnabled := eq (include "oauth2-proxy.redis.enabled" .) "true" -}}
 {{- $redisValues := index .Values "redis-ha" | default dict -}}
 apiVersion: apps/v1
@@ -27,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if ne (include "oauth2-proxy.legacy-config.mode" .) "existing-configmap" }}
+        {{- if not (has $legacyConfigMode (list "existing-configmap" "no-config")) }}
         checksum/config: {{ include "oauth2-proxy.legacy-config.content" . | sha256sum }}
         {{- end }}
         {{- if .Values.alphaConfig.enabled }}
@@ -145,7 +146,9 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
+        {{- if ne $legacyConfigMode "no-config" }}
           - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        {{- end }}
         {{- if .Values.authenticatedEmailsFile.enabled }}
         {{- if .Values.authenticatedEmailsFile.template }}
           - --authenticated-emails-file=/etc/oauth2-proxy/{{ .Values.authenticatedEmailsFile.template }}
@@ -302,9 +305,11 @@ spec:
           readOnly: true
 {{- end }}
 {{- end }}
+{{- if ne $legacyConfigMode "no-config" }}
         - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
           name: configmain
           subPath: oauth2_proxy.cfg
+{{- end }}
 {{- if .Values.alphaConfig.enabled }}
         - mountPath: /etc/oauth2_proxy/oauth2_proxy.yml
           name: configalpha
@@ -368,10 +373,12 @@ spec:
           name: {{ template "oauth2-proxy.fullname" . }}-wait-for-redis
           defaultMode: 0775
 {{- end }}
+{{- if ne $legacyConfigMode "no-config" }}
       - configMap:
           defaultMode: 420
           name: {{ include "oauth2-proxy.legacy-config.name" . | trim }}
         name: configmain
+{{- end }}
 {{- if .Values.alphaConfig.enabled }}
 {{- if .Values.alphaConfig.existingConfig }}
       - configMap:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -65,6 +65,7 @@ config:
   # 3. If configFile is empty/not set, the config is auto-generated
   #    from emailDomains and, when alphaConfig is disabled, upstreams.
   # 4. When alphaConfig.enabled=false and forceLegacyConfig=false,
+  #    and neither config.configFile nor config.existingConfig are set,
   #    no ConfigMap is generated or mounted. Use this when you manage
   #    oauth2-proxy configuration entirely via external means (e.g.,
   #    CSI SecretStore Driver, extraVolumes, etc.).
@@ -114,6 +115,7 @@ config:
   #    - Move any other relevant settings into alphaConfig and/or
   #      flags rather than relying on a custom legacy configFile.
   # 3) If forceLegacyConfig and alphaConfig.enabled are both false,
+  #    and no configFile or existingConfig is provided,
   #    no ConfigMap is generated or mounted. This is useful when
   #    managing config externally (e.g., CSI SecretStore Driver).
   forceLegacyConfig: true

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -87,7 +87,7 @@ config:
   #     config.configFile or config.existingConfig, OR
   #   - alphaConfig.enabled is false AND no configFile/existingConfig
   #     is provided (setting forceLegacyConfig=false disables config
-  #     generation entirely — see option 3 below).
+  #     generation entirely — see "no-config mode" below).
   #
   # Auto-generated config when alphaConfig.enabled=true is always a
   # minimal legacy config (no upstreams), regardless of this flag.
@@ -117,10 +117,12 @@ config:
   #      instead (see examples below).
   #    - Move any other relevant settings into alphaConfig and/or
   #      flags rather than relying on a custom legacy configFile.
-  # 3) If forceLegacyConfig and alphaConfig.enabled are both false,
-  #    and no configFile or existingConfig is provided,
-  #    no ConfigMap is generated or mounted. This is useful when
-  #    managing config externally (e.g., CSI SecretStore Driver).
+  #
+  # no-config mode:
+  # If forceLegacyConfig and alphaConfig.enabled are both false,
+  # and no configFile or existingConfig is provided, no ConfigMap
+  # is generated or mounted. This is useful when managing config
+  # externally (e.g., CSI SecretStore Driver).
   forceLegacyConfig: true
   #
   # Custom configuration file: oauth2_proxy.cfg (overrides

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -82,9 +82,12 @@ config:
   upstreams: ["file:///dev/null"]
   # Behavior when using alphaConfig together with a custom config file
   #
-  # This flag only has an effect when:
-  #   - alphaConfig.enabled is true, AND
-  #   - you provide a custom config.configFile or config.existingConfig.
+  # This flag has an effect when:
+  #   - alphaConfig.enabled is true AND you provide a custom
+  #     config.configFile or config.existingConfig, OR
+  #   - alphaConfig.enabled is false AND no configFile/existingConfig
+  #     is provided (setting forceLegacyConfig=false disables config
+  #     generation entirely — see option 3 below).
   #
   # Auto-generated config when alphaConfig.enabled=true is always a
   # minimal legacy config (no upstreams), regardless of this flag.

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -64,6 +64,10 @@ config:
   #    generates a minimal legacy config from emailDomains only.
   # 3. If configFile is empty/not set, the config is auto-generated
   #    from emailDomains and, when alphaConfig is disabled, upstreams.
+  # 4. When alphaConfig.enabled=false and forceLegacyConfig=false,
+  #    no ConfigMap is generated or mounted. Use this when you manage
+  #    oauth2-proxy configuration entirely via external means (e.g.,
+  #    CSI SecretStore Driver, extraVolumes, etc.).
   configFile: ""
   # Email domains allowed to authenticate when the chart generates
   # the main oauth2_proxy.cfg.
@@ -109,6 +113,9 @@ config:
   #      instead (see examples below).
   #    - Move any other relevant settings into alphaConfig and/or
   #      flags rather than relying on a custom legacy configFile.
+  # 3) If forceLegacyConfig and alphaConfig.enabled are both false,
+  #    no ConfigMap is generated or mounted. This is useful when
+  #    managing config externally (e.g., CSI SecretStore Driver).
   forceLegacyConfig: true
   #
   # Custom configuration file: oauth2_proxy.cfg (overrides


### PR DESCRIPTION
## Summary

- Add `no-config` legacy-config mode: when `alphaConfig.enabled=false` and `forceLegacyConfig=false`, skip ConfigMap generation, volume mount, and `--config` flag
- This restores support for users managing oauth2-proxy configuration via external means (e.g., CSI SecretStore Driver) that was broken by #385
- Add CI test values file for the no-config scenario
- Update values.yaml documentation

Fixes the issue reported in https://github.com/oauth2-proxy/manifests/pull/385#discussion_r3001082837

## Test plan

- [ ] `helm template` with `no-config-values.yaml` produces no ConfigMap, no `--config` flag, no config volume mount
- [ ] `helm template` with `default-values.yaml` still generates ConfigMap and `--config` flag (no regression)
- [ ] `helm lint` passes for all CI value files (24/24 pass)
- [ ] Verify external config management via CSI SecretStore Driver works with `config.forceLegacyConfig: false`