### PR TITLE
feat: add alpha-config helpers and deprecation guards

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 10.4.3
+version: 10.5.0
 apiVersion: v2
 appVersion: 7.15.2
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -30,8 +30,13 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump OAuth2 Proxy image to v7.15.2
+    - kind: added
+      description: Add alpha-config.source and alpha-config.name helpers for centralized alpha config resolution
       links:
         - name: GitHub PR
-          url: https://github.com/oauth2-proxy/manifests/pull/406
+          url: https://github.com/oauth2-proxy/manifests/pull/405
+    - kind: added
+      description: Add deprecation guards for invalid alphaConfig combinations
+      links:
+        - name: GitHub PR
+          url: https://github.com/oauth2-proxy/manifests/pull/405

--- a/helm/oauth2-proxy/ci/alphaconfig-7-existing-secret-values.yaml
+++ b/helm/oauth2-proxy/ci/alphaconfig-7-existing-secret-values.yaml
@@ -1,0 +1,23 @@
+# Test Case 7: alphaConfig enabled + existingSecret
+# Expected: Chart mounts the external alpha Secret instead of generating one.
+
+alphaConfig:
+  enabled: true
+  existingSecret: my-external-alpha-secret
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: my-external-alpha-secret
+    type: Opaque
+    stringData:
+      oauth2_proxy.yml: |
+        ---
+        server:
+          BindAddress: 0.0.0.0:4180
+        providers:
+          - id: google
+            provider: google
+            clientID: fake-client-id
+            clientSecret: fake-client-secret

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -164,6 +164,36 @@ metricsServer:
 {{- end -}}
 
 {{/*
+Alpha config source resolution:
+- disabled: alphaConfig.enabled=false
+- existing-configmap: alphaConfig.existingConfig is set
+- existing-secret: alphaConfig.existingSecret is set
+- generated: alphaConfig enabled with no external source
+*/}}
+{{- define "oauth2-proxy.alpha-config.source" -}}
+{{- if not .Values.alphaConfig.enabled -}}
+disabled
+{{- else if .Values.alphaConfig.existingConfig -}}
+existing-configmap
+{{- else if .Values.alphaConfig.existingSecret -}}
+existing-secret
+{{- else -}}
+generated
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.alpha-config.name" -}}
+{{- $source := include "oauth2-proxy.alpha-config.source" . -}}
+{{- if eq $source "existing-configmap" -}}
+{{- .Values.alphaConfig.existingConfig -}}
+{{- else if eq $source "existing-secret" -}}
+{{- .Values.alphaConfig.existingSecret -}}
+{{- else if eq $source "generated" -}}
+{{- printf "%s-alpha" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 If `config.forceLegacyConfig=false`, the chart ignores both the `config.configFile` and `config.existingConfig` overrides and only generates a minimal necessary legacy config.
 If `config.existingConfig` is set and `config.forceLegacyConfig=true`, the external ConfigMap is mounted into the mounted file.
 If `config.configFile` is set and `config.forceLegacyConfig=true`, the chart renders that inline content into the mounted file.

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -189,7 +189,7 @@ generated
 {{- else if eq $source "existing-secret" -}}
 {{- .Values.alphaConfig.existingSecret -}}
 {{- else if eq $source "generated" -}}
-{{- printf "%s-alpha" (include "oauth2-proxy.fullname" .) -}}
+{{- printf "%s-alpha" (include "oauth2-proxy.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $alphaSource := include "oauth2-proxy.alpha-config.source" . -}}
 {{- $redisEnabled := eq (include "oauth2-proxy.redis.enabled" .) "true" -}}
 {{- $redisValues := index .Values "redis-ha" | default dict -}}
 apiVersion: apps/v1
@@ -30,7 +31,7 @@ spec:
         {{- if ne (include "oauth2-proxy.legacy-config.mode" .) "existing-configmap" }}
         checksum/config: {{ include "oauth2-proxy.legacy-config.content" . | sha256sum }}
         {{- end }}
-        {{- if .Values.alphaConfig.enabled }}
+        {{- if eq $alphaSource "generated" }}
         checksum/alpha-config: {{ include "oauth2-proxy.alpha-config" . | sha256sum }}
         {{- end }}
         {{- if .Values.authenticatedEmailsFile.enabled }}
@@ -305,7 +306,7 @@ spec:
         - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
           name: configmain
           subPath: oauth2_proxy.cfg
-{{- if .Values.alphaConfig.enabled }}
+{{- if ne $alphaSource "disabled" }}
         - mountPath: /etc/oauth2_proxy/oauth2_proxy.yml
           name: configalpha
           subPath: oauth2_proxy.yml
@@ -372,18 +373,16 @@ spec:
           defaultMode: 420
           name: {{ include "oauth2-proxy.legacy-config.name" . | trim }}
         name: configmain
-{{- if .Values.alphaConfig.enabled }}
-{{- if .Values.alphaConfig.existingConfig }}
+{{- if eq $alphaSource "existing-configmap" }}
       - configMap:
           defaultMode: 420
-          name: {{ .Values.alphaConfig.existingConfig }}
+          name: {{ include "oauth2-proxy.alpha-config.name" . }}
         name: configalpha
-{{- else }}
+{{- else if or (eq $alphaSource "existing-secret") (eq $alphaSource "generated") }}
       - secret:
           defaultMode: 420
-          secretName: {{ if .Values.alphaConfig.existingSecret }}{{ .Values.alphaConfig.existingSecret }}{{ else }}{{ template "oauth2-proxy.fullname" . }}-alpha{{ end }}
+          secretName: {{ include "oauth2-proxy.alpha-config.name" . }}
         name: configalpha
-{{- end }}
 {{- end }}
 {{- if ne (len .Values.extraVolumes) 0 }}
 {{ tpl (toYaml .Values.extraVolumes) . | indent 6 }}

--- a/helm/oauth2-proxy/templates/deprecation.yaml
+++ b/helm/oauth2-proxy/templates/deprecation.yaml
@@ -6,7 +6,7 @@
         {{ fail "`alphaConfig.existingConfig` and `alphaConfig.existingSecret` are mutually exclusive. Configure exactly one external alpha config source." }}
     {{- end }}
     {{- if and .Values.alphaConfig.enabled (or .Values.alphaConfig.existingConfig .Values.alphaConfig.existingSecret) (or .Values.alphaConfig.serverConfigData .Values.alphaConfig.metricsConfigData .Values.alphaConfig.configData .Values.alphaConfig.configFile) }}
-        {{ fail "External alpha config sources (`alphaConfig.existingConfig` or `alphaConfig.existingSecret`) cannot be combined with generated alpha config content (`serverConfigData`, `metricsConfigData`, `configData`, or `configFile`). Choose one alpha config source." }}
+        {{ fail "External alpha config sources (`alphaConfig.existingConfig` or `alphaConfig.existingSecret`) cannot be combined with generated alpha config content (`alphaConfig.serverConfigData`, `alphaConfig.metricsConfigData`, `alphaConfig.configData`, or `alphaConfig.configFile`). Choose one alpha config source." }}
     {{- end }}
     {{- if eq ( include "capabilities.ingress.apiVersion" . ) "networking.k8s.io/v1" -}}
         {{- range .Values.ingress.extraPaths }}

--- a/helm/oauth2-proxy/templates/deprecation.yaml
+++ b/helm/oauth2-proxy/templates/deprecation.yaml
@@ -2,6 +2,12 @@
     {{- if .Values.service.port }}
         {{ fail "`service.port` does no longer exist. It has been renamed to `service.portNumber`" }}
     {{- end }}
+    {{- if and .Values.alphaConfig.enabled .Values.alphaConfig.existingConfig .Values.alphaConfig.existingSecret }}
+        {{ fail "`alphaConfig.existingConfig` and `alphaConfig.existingSecret` are mutually exclusive. Configure exactly one external alpha config source." }}
+    {{- end }}
+    {{- if and .Values.alphaConfig.enabled (or .Values.alphaConfig.existingConfig .Values.alphaConfig.existingSecret) (or .Values.alphaConfig.serverConfigData .Values.alphaConfig.metricsConfigData .Values.alphaConfig.configData .Values.alphaConfig.configFile) }}
+        {{ fail "External alpha config sources (`alphaConfig.existingConfig` or `alphaConfig.existingSecret`) cannot be combined with generated alpha config content (`serverConfigData`, `metricsConfigData`, `configData`, or `configFile`). Choose one alpha config source." }}
+    {{- end }}
     {{- if eq ( include "capabilities.ingress.apiVersion" . ) "networking.k8s.io/v1" -}}
         {{- range .Values.ingress.extraPaths }}
             {{- if or (.backend.serviceName) (.backend.servicePort) }}

--- a/helm/oauth2-proxy/templates/secret-alpha.yaml
+++ b/helm/oauth2-proxy/templates/secret-alpha.yaml
@@ -1,9 +1,4 @@
-{{-
-  if and
-    .Values.alphaConfig.enabled
-    (not .Values.alphaConfig.existingConfig)
-    (not .Values.alphaConfig.existingSecret)
-}}
+{{- if eq (include "oauth2-proxy.alpha-config.source" .) "generated" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,7 +9,7 @@ metadata:
   labels:
     app: {{ template "oauth2-proxy.name" . }}
     {{- include "oauth2-proxy.labels" . | indent 4 }}
-  name: {{ template "oauth2-proxy.fullname" . }}-alpha
+  name: {{ include "oauth2-proxy.alpha-config.name" . }}
   namespace: {{ template "oauth2-proxy.namespace" $ }}
 data:
   oauth2_proxy.yml: {{ include "oauth2-proxy.alpha-config" . | b64enc | quote }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -165,9 +165,13 @@ alphaConfig:
   # Arbitrary configuration to append
   # This is treated as a Go template and rendered with the root context
   configFile: ""
-  # Use an existing config map (see secret-alpha.yaml for required fields)
+  # Use an existing config map (see secret-alpha.yaml for required fields).
+  # Mutually exclusive with existingSecret and all generated alpha config
+  # content options (serverConfigData, metricsConfigData, configData, configFile).
   existingConfig: ~
-  # Use an existing secret
+  # Use an existing secret.
+  # Mutually exclusive with existingConfig and all generated alpha config
+  # content options (serverConfigData, metricsConfigData, configData, configFile).
   existingSecret: ~
   #
   # NOTE: When using alphaConfig with external secrets (e.g., Azure


### PR DESCRIPTION
## Summary

Structural improvements to alpha config handling, cherry-picked from the non-bugfix parts of #402:

- Add `alpha-config.source` and `alpha-config.name` template helpers to centralize scattered inline conditionals for alpha config type detection and name resolution
- Add deprecation guards that fail fast on invalid alpha config combinations:
  - `existingConfig` + `existingSecret` set together
  - External alpha source combined with generated content (`configData`, `configFile`, etc.)
- Simplify `secret-alpha.yaml` and `deployment.yaml` volume definitions using the new helpers
- Only compute `checksum/alpha-config` annotation for generated alpha configs (not external)
- Document mutual exclusivity of `existingConfig`/`existingSecret` in `values.yaml`
- Add CI test for `alphaConfig.existingSecret` scenario

**Not included** (intentionally):
- Renaming `legacy-config.mode` → `legacy-config.source` (breaking for custom templates)
- Always-on debug annotations (`legacy/source`, `alpha/source`)
- `no-config` mode (already in #404)

## Test plan

- [ ] `helm lint` passes for all 24 CI value files
- [ ] `helm template` with `alphaconfig-7-existing-secret-values.yaml` mounts external secret correctly (no generated secret)
- [ ] `helm template` with `alphaconfig-1-legacy-true-values.yaml` still generates alpha secret with checksum
- [ ] Deprecation guards reject invalid combinations (`existingConfig` + `existingSecret`, external + generated)