### PR TITLE
chore(dep): bump app version to v7.15.2

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 10.4.2
+version: 10.4.3
 apiVersion: v2
-appVersion: 7.15.1
+appVersion: 7.15.2
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
@@ -31,7 +31,7 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump OAuth2 Proxy image to v7.15.1
+      description: Bump OAuth2 Proxy image to v7.15.2
       links:
         - name: GitHub PR
-          url: https://github.com/oauth2-proxy/manifests/pull/403
+          url: https://github.com/oauth2-proxy/manifests/pull/406


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Bump OAuth2 Proxy version to v7.15.2

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have bumped the version in the Chart.yaml according to [Semantic Versioning](https://semver.org).
- [X] I have updated the documentation/CHANGELOG at the bottom of the Chart.yaml
- [X] I have [signed off](https://github.com/apps/dco) all my commits.
- [ ] (Optional) I have updated the Chart.lock for dependency updates
- [ ] (Optional) I have implemented helm tests for new feature flags
