### PR TITLE
chore: bump oauth2 proxy to v7.15.3

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 10.6.0
+version: 10.6.1
 apiVersion: v2
-appVersion: 7.15.2
+appVersion: 7.15.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
@@ -30,8 +30,8 @@ maintainers:
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Added name attribute for HTTPRoute rules
+    - kind: changed
+      description: Bump OAuth2 Proxy app version to 7.15.3
       links:
         - name: GitHub PR
-          url: https://github.com/oauth2-proxy/manifests/pull/407
+          url: https://github.com/oauth2-proxy/manifests/pull/412


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Bump to OAuth2 Proxy [v7.15.3](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.15.3)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have bumped the version in the Chart.yaml according to [Semantic Versioning](https://semver.org).
- [X] I have updated the documentation/CHANGELOG at the bottom of the Chart.yaml
- [X] I have [signed off](https://github.com/apps/dco) all my commits.
- [ ] (Optional) I have updated the Chart.lock for dependency updates
- [ ] (Optional) I have implemented helm tests for new feature flags
