### PR TITLE
feat(GatewayAPI): Add timeouts for httpRoute

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 10.7.0
+version: 10.8.0
 apiVersion: v2
 appVersion: 7.15.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -31,12 +31,7 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Add alpha-config.source and alpha-config.name helpers for centralized alpha config resolution
+      description: Add support for per-rule timeouts (request and backendRequest) on the Gateway API HTTPRoute
       links:
         - name: GitHub PR
-          url: https://github.com/oauth2-proxy/manifests/pull/405
-    - kind: added
-      description: Add deprecation guards for invalid alphaConfig combinations
-      links:
-        - name: GitHub PR
-          url: https://github.com/oauth2-proxy/manifests/pull/405
+          url: https://github.com/oauth2-proxy/manifests/pull/417

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -372,6 +372,9 @@ gatewayApi:
             add:
               - name: X-Auth-Request
                 value: "true"
+      timeouts:
+        request: 10s
+        backendRequest: 5s
   labels:
     app: oauth2-proxy
   annotations:
@@ -380,6 +383,8 @@ gatewayApi:
 
 If you don't specify custom rules, the chart will create a default rule that matches all paths with `PathPrefix: /` and routes to the oauth2-proxy service.
 If you don't specify a sectionName, the rules will be applied to all listeners of the referenced Gateway.
+
+Each rule can optionally define `timeouts.request` and `timeouts.backendRequest` strings, e.g. `"10s"`, `"500ms"`). See the [HTTPRoute timeouts](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional) reference for details.
 
 ### Targeting Rules with Policies via `sectionName`
 

--- a/helm/oauth2-proxy/ci/gateway-api-timeouts.yaml
+++ b/helm/oauth2-proxy/ci/gateway-api-timeouts.yaml
@@ -1,0 +1,16 @@
+# Gateway API configuration with custom HTTPRoute rule timeouts
+gatewayApi:
+  enabled: true
+  gatewayRef:
+    name: example-gateway
+    namespace: gateway-system
+  hostnames:
+  - oauth.example.com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /oauth2
+    timeouts:
+      request: 30s
+      backendRequest: 10s

--- a/helm/oauth2-proxy/templates/httproute.yaml
+++ b/helm/oauth2-proxy/templates/httproute.yaml
@@ -52,6 +52,10 @@ spec:
     filters:
     {{- toYaml .filters | nindent 4 }}
     {{- end }}
+    {{- if .timeouts }}
+    timeouts:
+    {{- toYaml .timeouts | nindent 6 }}
+    {{- end }}
   {{- end }}
   {{- else }}
   - matches:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -384,6 +384,12 @@ gatewayApi:
   #   - path:
   #       type: PathPrefix
   #       value: /
+  #   # Request timeouts for this rule (Gateway API Duration strings, e.g. "10s", "500ms")
+  #   # backendRequest must not be greater than request.
+  #   # https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproutetimeouts
+  #   timeouts:
+  #     request: 10s
+  #     backendRequest: 5s
   rules: []
   # Hostnames to match in the HTTPRoute
   # hostnames:


### PR DESCRIPTION
## Description

Add support for configuring per-rule HTTPRoute timeouts in the Gateway API HTTPRoute template

Each entry under gatewayApi.rules now accepts an optional timeouts block exposing the two Gateway API fields:

- timeouts.request — maximum duration for the gateway to respond to a client request
- timeouts.backendRequest — timeout for an individual request from the gateway to the backend

Both values are Gateway API Duration strings (e.g. "30s", "500ms")

The field is rendered only when set, so existing installations are unaffected and the default rule behaviour is unchanged

## Changes:

- templates/httproute.yaml: render timeouts for each rule when defined
- values.yaml: document the new timeouts field in the gatewayApi.rules example
- ci/gateway-api-timeouts.yaml: new CI values file covering a rule with custom request/backendRequest timeouts

## Checklist:

- [x] I have bumped the version in the Chart.yaml according to [Semantic Versioning](https://semver.org).
- [x] I have updated the documentation/CHANGELOG at the bottom of the Chart.yaml
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [ ] (Optional) I have updated the Chart.lock for dependency updates
- [x] (Optional) I have implemented helm tests for new feature flags
