### PR TITLE
feat(config): add 'tpl' usage for alphaConfig.existingSecret, alphaConfig.existingConfig, config.existingConfig, podAnnotations, podLabels, sessionStorage.redis.existingSecret, sessionStorage.redis.sentinel.existingSecret

### DIFF
--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 10.7.0
+version: 10.8.0
 apiVersion: v2
 appVersion: 7.15.3
 home: https://oauth2-proxy.github.io/oauth2-proxy/
@@ -40,3 +40,8 @@ annotations:
       links:
         - name: GitHub PR
           url: https://github.com/oauth2-proxy/manifests/pull/405
+    - kind: added
+      description: Add 'tpl' usage for alphaConfig.existingSecret, alphaConfig.existingConfig, config.existingConfig, podAnnotations and podLabels
+      links:
+        - name: GitHub PR
+          url: https://github.com/oauth2-proxy/manifests/pull/418

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -45,3 +45,10 @@ annotations:
       links:
         - name: GitHub PR
           url: https://github.com/oauth2-proxy/manifests/pull/418
+    - kind: added
+      description: Add 'tpl' usage for sessionStorage.redis.existingSecret and sessionStorage.redis.sentinel.existingSecret
+      links:
+        - name: GitHub Issue
+          url: https://github.com/oauth2-proxy/manifests/issues/409
+        - name: GitHub PR
+          url: https://github.com/oauth2-proxy/manifests/pull/418

--- a/helm/oauth2-proxy/README.md
+++ b/helm/oauth2-proxy/README.md
@@ -300,11 +300,11 @@ The following table lists the configurable parameters of the oauth2-proxy chart 
 | `serviceAccount.name`                                 | the service account name                                                                                                                                                                                                                                         | ``                                                                                                   |
 | `sessionStorage.redis.clientType`                     | Allows the user to select which type of client will be used for the Redis instance. Possible options are: `sentinel`, `cluster` or `standalone`                                                                                                                  | `standalone`                                                                                         |
 | `sessionStorage.redis.cluster.connectionUrls`         | List of Redis cluster connection URLs (e.g., `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`)                                                                                                                                                             | `[]`                                                                                                 |
-| `sessionStorage.redis.existingSecret`                 | Name of the Kubernetes secret containing the Redis & Redis sentinel password values (see also `sessionStorage.redis.passwordKey`)                                                                                                                                | `""`                                                                                                 |
+| `sessionStorage.redis.existingSecret`                 | Name of the Kubernetes secret containing the Redis & Redis sentinel password values (see also `sessionStorage.redis.passwordKey`). Treated as a Go template and rendered with the root context                                                                   | `""`                                                                                                 |
 | `sessionStorage.redis.passwordKey`                    | Key of the Kubernetes secret data containing the Redis password value                                                                                                                                                                                            | `redis-password`                                                                                     |
 | `sessionStorage.redis.password`                       | Redis password. Applicable for all Redis configurations. Taken from Redis subchart secret if not set. `sessionStorage.redis.existingSecret` takes precedence                                                                                                     | `nil`                                                                                                |
 | `sessionStorage.redis.sentinel.connectionUrls`        | List of Redis sentinel connection URLs (e.g. `["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]`)                                                                                                                                                             | `[]`                                                                                                 |
-| `sessionStorage.redis.sentinel.existingSecret`        | Name of the Kubernetes secret containing the Redis sentinel password value (see also `sessionStorage.redis.sentinel.passwordKey`). Default: `sessionStorage.redis.existingSecret`                                                                                | `""`                                                                                                 |
+| `sessionStorage.redis.sentinel.existingSecret`        | Name of the Kubernetes secret containing the Redis sentinel password value (see also `sessionStorage.redis.sentinel.passwordKey`). Default: `sessionStorage.redis.existingSecret`. Treated as a Go template and rendered with the root context                   | `""`                                                                                                 |
 | `sessionStorage.redis.sentinel.masterName`            | Redis sentinel master name                                                                                                                                                                                                                                       | `nil`                                                                                                |
 | `sessionStorage.redis.sentinel.passwordKey`           | Key of the Kubernetes secret data containing the Redis sentinel password value                                                                                                                                                                                   | `redis-sentinel-password`                                                                            |
 | `sessionStorage.redis.sentinel.password`              | Redis sentinel password. Used only for sentinel connection; any Redis node passwords need to use `sessionStorage.redis.password`                                                                                                                                 | `nil`                                                                                                |
@@ -449,6 +449,28 @@ extraEnv:
     value: test_value_1
   - name: TEST_ENV_VAR_2
     value: '{{ .Values.tplValue }}'
+```
+
+## External resource name templating
+
+Values pointing at resources managed outside of the chart are treated as Go templates and rendered with the root context.
+This is useful when the chart runs as a subchart and the resource name is derived from the parent release or generated by an operator.
+
+Supported values:
+
+- `alphaConfig.existingConfig`
+- `alphaConfig.existingSecret`
+- `config.existingConfig`
+- `config.existingSecret`
+- `sessionStorage.redis.existingSecret`
+- `sessionStorage.redis.sentinel.existingSecret`
+
+```yaml
+...
+sessionStorage:
+  type: redis
+  redis:
+    existingSecret: '{{ .Release.Name }}-redis'
 ```
 
 ## Custom templates configuration

--- a/helm/oauth2-proxy/ci/alphaconfig-tpl-existing-secret-values.yaml
+++ b/helm/oauth2-proxy/ci/alphaconfig-tpl-existing-secret-values.yaml
@@ -1,0 +1,25 @@
+# Test Case: alphaConfig enabled + existingSecret TPL
+# Expected: Chart mounts the external alpha Secret instead of generating one.
+
+tplValue: prefix
+
+alphaConfig:
+  enabled: true
+  existingSecret: '{{ .Values.tplValue }}-alpha-secret'
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: '{{ .Values.tplValue }}-alpha-secret'
+    type: Opaque
+    stringData:
+      oauth2_proxy.yml: |
+        ---
+        server:
+          BindAddress: 0.0.0.0:4180
+        providers:
+          - id: google
+            provider: google
+            clientID: fake-client-id
+            clientSecret: fake-client-secret

--- a/helm/oauth2-proxy/ci/config-tpl-existing-configmap-values.yaml
+++ b/helm/oauth2-proxy/ci/config-tpl-existing-configmap-values.yaml
@@ -1,0 +1,17 @@
+# Test Case: config + existingConfig TPL
+# Expected: Chart mounts the external config ConfigMap instead of generating one.
+
+tplValue: prefix
+
+config:
+  existingConfig: '{{ .Values.tplValue }}-config'
+
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ .Values.tplValue }}-config'
+    data:
+      oauth2_proxy.cfg: |
+        email_domains = [ "*" ]
+        upstreams = [ "file:///dev/null" ]

--- a/helm/oauth2-proxy/ci/config-tpl-existing-secret-values.yaml
+++ b/helm/oauth2-proxy/ci/config-tpl-existing-secret-values.yaml
@@ -1,0 +1,18 @@
+# Test Case: config + existingSecret TPL
+# Expected: Chart mounts the external Secret instead of generating one.
+
+tplValue: prefix
+
+config:
+  existingSecret: '{{ .Values.tplValue }}-secret'
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: '{{ .Values.tplValue }}-secret'
+    type: Opaque
+    stringData:
+      client-id: fake-client-id
+      client-secret: fake-client-secret
+      cookie-secret: fake-cookie-secret-of-24

--- a/helm/oauth2-proxy/ci/redis-tpl-existing-secret-values.yaml
+++ b/helm/oauth2-proxy/ci/redis-tpl-existing-secret-values.yaml
@@ -1,0 +1,79 @@
+# Test Case: sessionStorage.redis + existingSecret TPL
+# Expected: Chart reads the redis password from the external Secret instead of generating one.
+
+tplValue: prefix
+
+sessionStorage:
+  type: redis
+  redis:
+    clientType: "standalone"
+    existingSecret: '{{ .Values.tplValue }}-redis'
+
+extraObjects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: '{{ .Values.tplValue }}-redis'
+    type: Opaque
+    stringData:
+      redis-password: foo
+
+# provision an instance of the redis-ha sub-chart
+redis-ha:
+  enabled: true
+
+  redisPassword: foo
+
+  replicas: 1
+
+  # Remove sentinel overhead, speed up startup and redis itself
+  sentinel:
+    livenessProbe:
+      enabled: false
+    readinessProbe:
+      enabled: false
+    startupProbe:
+      enabled: false
+    quorum: 1
+
+  hardAntiAffinity: false
+
+  redis:
+    config:
+      min-replicas-to-write: 0
+      save: ""
+      appendonly: "no"
+
+    terminationGracePeriodSeconds: 10
+    livenessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 2
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 2
+    startupProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 2
+      timeoutSeconds: 3
+      failureThreshold: 10
+  splitBrainDetection:
+    interval: 60
+  persistentVolume:
+    enabled: false
+  emptyDir: {}
+  haproxy:
+    enabled: false
+  exporter:
+    enabled: false
+  sysctlImage:
+    enabled: false
+  hostPath:
+    chown: false
+
+initContainers:
+  waitForRedis:
+    enabled: true

--- a/helm/oauth2-proxy/ci/tpl-values.yaml
+++ b/helm/oauth2-proxy/ci/tpl-values.yaml
@@ -63,6 +63,12 @@ deploymentLabels:
 deploymentAnnotations:
   test-annotations/test: "{{ $.Release.Name }}"
 
+podAnnotations:
+  test-annotations/test: "{{ $.Release.Name }}"
+
+podLabels:
+  test-pod-label/test: "{{ $.Release.Name }}"
+
 autoscaling:
   annotations:
     test-annotations/test: "{{ $.Release.Name }}"

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -185,9 +185,9 @@ generated
 {{- define "oauth2-proxy.alpha-config.name" -}}
 {{- $source := include "oauth2-proxy.alpha-config.source" . -}}
 {{- if eq $source "existing-configmap" -}}
-{{- .Values.alphaConfig.existingConfig -}}
+{{- printf "%s" (tpl .Values.alphaConfig.existingConfig $) -}}
 {{- else if eq $source "existing-secret" -}}
-{{- .Values.alphaConfig.existingSecret -}}
+{{- printf "%s" (tpl .Values.alphaConfig.existingSecret $) -}}
 {{- else if eq $source "generated" -}}
 {{- printf "%s-alpha" (include "oauth2-proxy.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -226,7 +226,7 @@ generated-legacy
 
 {{- define "oauth2-proxy.legacy-config.name" -}}
 {{- if eq (include "oauth2-proxy.legacy-config.mode" .) "existing-configmap" -}}
-{{- .Values.config.existingConfig -}}
+{{- printf "%s" (tpl .Values.config.existingConfig $) -}}
 {{- else -}}
 {{- template "oauth2-proxy.fullname" . -}}
 {{- end -}}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -217,7 +217,7 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if .Values.sessionStorage.redis.existingSecret }}
-              name: {{ .Values.sessionStorage.redis.existingSecret }}
+              name: {{ tpl .Values.sessionStorage.redis.existingSecret $ }}
               {{- else if .Values.sessionStorage.redis.password }}
               name: {{ template "oauth2-proxy.fullname" . }}-redis-access
               {{- else }}
@@ -245,7 +245,7 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if or .Values.sessionStorage.redis.sentinel.existingSecret .Values.sessionStorage.redis.existingSecret }}
-              name: {{ .Values.sessionStorage.redis.sentinel.existingSecret | default .Values.sessionStorage.redis.existingSecret }}
+              name: {{ tpl (.Values.sessionStorage.redis.sentinel.existingSecret | default .Values.sessionStorage.redis.existingSecret) $ }}
               {{- else }}
               name: {{ template "oauth2-proxy.fullname" . }}-redis-access
               {{- end }}

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -47,14 +47,14 @@ spec:
 {{- if .Values.htpasswdFile.enabled }}
         checksum/htpasswd: {{ toYaml .Values.htpasswdFile.entries | sha256sum }}
 {{- end }}
-    {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- with .Values.podAnnotations }}
+{{ tpl ( toYaml . ) $ | indent 8 }}
     {{- end }}
       labels:
         app: {{ template "oauth2-proxy.name" . }}
         {{- include "oauth2-proxy.labels" . | indent 8 }}
-      {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
+      {{- with .Values.podLabels }}
+{{ tpl ( toYaml . ) $ | indent 8 }}
       {{- end }}
     spec:
     {{- if .Values.priorityClassName }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -23,6 +23,11 @@ config:
   clientID: "XXXXXXX"
   # OAuth client secret
   clientSecret: "XXXXXXXX"
+  # Custom secret name instead of generating one with 'clientID', 'clientSecret' and 'cookieSecret'.
+  # Secret keys must be the one provided with 'requiredSecretKeys' below.
+  # Mutually exclusive with 'clientID', 'clientSecret' and 'cookieSecret'.
+  # Supports Helm templating, e.g. '{{ .Release.Name }}-secret' or '{{ include "myapp.oauth2-proxy.secretName" . }}'
+  existingSecret: ~
   # List of secret keys to include in the secret and expose as environment variables.
   # By default, all three secrets are required. To exclude certain secrets
   # (e.g., when using federated token authentication), remove them from this list.
@@ -135,8 +140,10 @@ config:
   # Use an existing config map (see configmap.yaml for required fields)
   # This is ignored when alphaConfig.enabled=true and
   # forceLegacyConfig=false.
+  # Supports Helm templating, e.g. '{{ .Release.Name }}-config' or '{{ include "myapp.oauth2-proxy.configName" . }}'
   # Example:
   # existingConfig: config
+  # existingConfig: '{{ .Release.Name }}-config'
   existingConfig: ~
 
 alphaConfig:
@@ -182,10 +189,12 @@ alphaConfig:
   # Use an existing config map (see secret-alpha.yaml for required fields).
   # Mutually exclusive with existingSecret and all generated alpha config
   # content options (serverConfigData, metricsConfigData, configData, configFile).
+  # Supports Helm templating, e.g. '{{ .Release.Name }}-config' or '{{ include "myapp.oauth2-proxy.configName" . }}'
   existingConfig: ~
   # Use an existing secret.
   # Mutually exclusive with existingConfig and all generated alpha config
   # content options (serverConfigData, metricsConfigData, configData, configFile).
+  # Supports Helm templating, e.g. '{{ .Release.Name }}-secret' or '{{ include "myapp.oauth2-proxy.secretName" . }}'
   existingSecret: ~
   #
   # NOTE: When using alphaConfig with external secrets (e.g., Azure

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -613,6 +613,7 @@ sessionStorage:
   type: cookie
   redis:
     # Name of the Kubernetes secret containing the redis & redis sentinel password values (see also `sessionStorage.redis.passwordKey`)
+    # Supports Helm templating, e.g. '{{ .Release.Name }}-redis' or '{{ include "myapp.redis.secretName" . }}'
     existingSecret: ""
     # Redis password value. Applicable for all Redis configurations. Taken from redis subchart secret if not set. `sessionStorage.redis.existingSecret` takes precedence
     password: ""
@@ -631,6 +632,7 @@ sessionStorage:
       # - "redis://127.0.0.1:8001"
     sentinel:
       # Name of the Kubernetes secret containing the redis sentinel password value (see also `sessionStorage.redis.sentinel.passwordKey`). Default: `sessionStorage.redis.existingSecret`
+      # Supports Helm templating, e.g. '{{ .Release.Name }}-redis' or '{{ include "myapp.redis.secretName" . }}'
       existingSecret: ""
       # Redis sentinel password. Used only for sentinel connection; any redis node passwords need to use `sessionStorage.redis.password`
       password: ""


### PR DESCRIPTION
## Description

Hello Team 👋

A small PR to wrap existingConfig and existingSecret, podAnnotations and podLabels with `tpl`.

My use case is to create a configmap in my parent chart `{{ .Release.Name }}-oauth2-proxy-custom` because I want to use some `.Values` within the configuration (redirect_url for instance).

Addition for podAnnotations and podLabels is to add consistency with other annotations / labels tpl usage and also for the pod `checksum/config`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have bumped the version in the Chart.yaml according to [Semantic Versioning](https://semver.org).
- [x] I have updated the documentation/CHANGELOG at the bottom of the Chart.yaml
- [x] I have [signed off](https://github.com/apps/dco) all my commits.
- [ ] (Optional) I have updated the Chart.lock for dependency updates
- [x] (Optional) I have implemented helm tests for new feature flags
